### PR TITLE
Add exporters, `exportData` method to `base-db` and make it work with Splitgraph

### DIFF
--- a/packages/base-db/base-db.ts
+++ b/packages/base-db/base-db.ts
@@ -47,6 +47,7 @@ export abstract class BaseDb<ConcretePluginMap extends PluginMap>
   protected authenticatedCredential?: AuthenticatedCredential;
   protected host: Host;
   protected database: Database;
+  protected opts: DbOptions<ConcretePluginMap>;
 
   constructor(opts: DbOptions<ConcretePluginMap>) {
     this.setAuthenticatedCredential(opts?.authenticatedCredential);
@@ -60,6 +61,7 @@ export abstract class BaseDb<ConcretePluginMap extends PluginMap>
         ...opts?.plugins.exporters,
       },
     };
+    this.opts = opts;
   }
 
   public setAuthenticatedCredential(

--- a/packages/base-db/plugin-bindings.ts
+++ b/packages/base-db/plugin-bindings.ts
@@ -12,8 +12,8 @@ type PluginMapShape = {
 
 export type PluginMap<
   ConcretePluginMap extends PluginMapShape = {
-    importers: any;
-    exporters: any;
+    importers: PluginMapShape["importers"];
+    exporters: PluginMapShape["exporters"];
   }
 > = {
   importers: {

--- a/packages/base-db/plugin-bindings.ts
+++ b/packages/base-db/plugin-bindings.ts
@@ -12,7 +12,7 @@ export type PluginMap<ConcretePluginMap extends Record<string, Plugin> = any> =
       : ConcretePluginMap[pluginName];
   };
 
-export interface Plugin {
+export interface BasePlugin {
   // importData: <
   //   SourceOptions extends Record<PropertyKey, unknown>,
   //   DestOptions extends Record<PropertyKey, unknown>,
@@ -23,10 +23,23 @@ export interface Plugin {
   //   destOptions: DestOptions
   // ) => Promise<{ response: ResultShape | null; error: ErrorShape | null }>;
 
+  __name?: string;
+}
+
+export interface ImportPlugin extends BasePlugin {
   importData: (
     sourceOptions: any,
     destOptions: any
   ) => Promise<{ response: any | null; error: any | null; info?: any | null }>;
 }
+
+export interface ExportPlugin extends BasePlugin {
+  exportData: (
+    sourceOptions: any,
+    destOptions: any
+  ) => Promise<{ response: any | null; error: any | null; info?: any | null }>;
+}
+
+export type Plugin = ImportPlugin | ExportPlugin;
 
 // export type PluginMap = Map<string, Plugin>;

--- a/packages/base-db/plugin-bindings.ts
+++ b/packages/base-db/plugin-bindings.ts
@@ -40,9 +40,10 @@ export type OptionalPluginMap<
   exporters: Partial<Exporters>;
 };
 
-export type PluginMapOptions<> = {};
-
-export type WithOptions<OuterClassT> = <InjectedOpts, InnerClassT>(
+export type WithOptions<OuterClassT> = <
+  InjectedOpts,
+  InnerClassT extends OuterClassT
+>(
   injectOpts: InjectedOpts
 ) => InnerClassT | OuterClassT;
 

--- a/packages/base-db/plugin-bindings.ts
+++ b/packages/base-db/plugin-bindings.ts
@@ -5,12 +5,42 @@
 
 // }
 
-export type PluginMap<ConcretePluginMap extends Record<string, Plugin> = any> =
-  {
-    [pluginName in keyof ConcretePluginMap]: ConcretePluginMap extends never
-      ? Plugin
-      : ConcretePluginMap[pluginName];
+type PluginMapShape = {
+  importers: Record<string, ImportPlugin>;
+  exporters: Record<string, ExportPlugin>;
+};
+
+export type PluginMap<
+  ConcretePluginMap extends PluginMapShape = {
+    importers: any;
+    exporters: any;
+  }
+> = {
+  importers: {
+    [pluginName in keyof ConcretePluginMap["importers"]]: ConcretePluginMap["importers"] extends never
+      ? ImportPlugin
+      : ConcretePluginMap["importers"][pluginName];
   };
+  exporters: {
+    [pluginName in keyof ConcretePluginMap["exporters"]]: ConcretePluginMap["exporters"] extends never
+      ? ExportPlugin
+      : ConcretePluginMap["exporters"][pluginName];
+  };
+};
+
+export type OptionalPluginMap<
+  ConcretePluginMap extends PluginMapShape = {
+    importers: any;
+    exporters: any;
+  },
+  Importers = PluginMap<ConcretePluginMap>["importers"],
+  Exporters = PluginMap<ConcretePluginMap>["exporters"]
+> = {
+  importers: Partial<Importers>;
+  exporters: Partial<Exporters>;
+};
+
+export type PluginMapOptions<> = {};
 
 export interface BasePlugin {
   // importData: <

--- a/packages/base-db/plugin-bindings.ts
+++ b/packages/base-db/plugin-bindings.ts
@@ -42,6 +42,14 @@ export type OptionalPluginMap<
 
 export type PluginMapOptions<> = {};
 
+export type WithOptions<OuterClassT> = <InjectedOpts, InnerClassT>(
+  injectOpts: InjectedOpts
+) => InnerClassT | OuterClassT;
+
+export interface WithOptionsInterface<ClassT> {
+  withOptions: WithOptions<ClassT>;
+}
+
 export interface BasePlugin {
   // importData: <
   //   SourceOptions extends Record<PropertyKey, unknown>,
@@ -54,9 +62,14 @@ export interface BasePlugin {
   // ) => Promise<{ response: ResultShape | null; error: ErrorShape | null }>;
 
   __name?: string;
+
+  graphqlEndpoint: string;
 }
 
+// export abstract class
+
 export interface ImportPlugin extends BasePlugin {
+  withOptions: WithOptions<ImportPlugin>;
   importData: (
     sourceOptions: any,
     destOptions: any
@@ -64,6 +77,7 @@ export interface ImportPlugin extends BasePlugin {
 }
 
 export interface ExportPlugin extends BasePlugin {
+  withOptions: WithOptions<ExportPlugin>;
   exportData: (
     sourceOptions: any,
     destOptions: any

--- a/packages/core/data-context.ts
+++ b/packages/core/data-context.ts
@@ -1,7 +1,9 @@
 import type { Client } from "@madatdata/base-client";
 import type { BaseDb } from "@madatdata/base-db";
 
-export interface DataContext<Db extends BaseDb<{}>> {
+export interface DataContext<
+  Db extends BaseDb<{ importers: {}; exporters: {} }>
+> {
   client: Client;
   db: Db;
 }

--- a/packages/core/seafowl.test.ts
+++ b/packages/core/seafowl.test.ts
@@ -87,12 +87,49 @@ describe("makeSeafowlHTTPContext", () => {
               "ssl": false,
             },
           },
+          "opts": {
+            "authenticatedCredential": undefined,
+            "database": {
+              "dbname": "seafowl",
+            },
+            "host": {
+              "apexDomain": "bogus",
+              "apiHost": "bogus",
+              "baseUrls": {
+                "auth": "bogus",
+                "gql": "bogus",
+                "sql": "http://127.0.0.1:8080/q",
+              },
+              "dataHost": "127.0.0.1:8080",
+              "postgres": {
+                "host": "127.0.0.1",
+                "port": 6432,
+                "ssl": false,
+              },
+            },
+            "plugins": {
+              "exporters": {},
+              "importers": {
+                "csv": ImportCSVPlugin {
+                  "graphqlEndpoint": "http://todo.test/should-not-be-required-property",
+                  "opts": {
+                    "transformRequestHeaders": [Function],
+                  },
+                  "transformRequestHeaders": [Function],
+                },
+              },
+            },
+          },
           "plugins": {
-            "csv": ImportCSVPlugin {
-              "opts": {
+            "exporters": {},
+            "importers": {
+              "csv": ImportCSVPlugin {
+                "graphqlEndpoint": "http://todo.test/should-not-be-required-property",
+                "opts": {
+                  "transformRequestHeaders": [Function],
+                },
                 "transformRequestHeaders": [Function],
               },
-              "transformRequestHeaders": [Function],
             },
           },
         },

--- a/packages/core/splitgraph.test.ts
+++ b/packages/core/splitgraph.test.ts
@@ -101,7 +101,7 @@ describe("makeSplitgraphHTTPContext", () => {
             },
             "plugins": {
               "exporters": {
-                "exportQuery": ExportQueryPlugin {
+                "exportQuery": _ExportQueryPlugin {
                   "graphqlClient": SplitgraphGraphQLClient {
                     "graphqlClient": GraphQLClient {
                       "options": {
@@ -180,7 +180,7 @@ describe("makeSplitgraphHTTPContext", () => {
           },
           "plugins": {
             "exporters": {
-              "exportQuery": ExportQueryPlugin {
+              "exportQuery": _ExportQueryPlugin {
                 "graphqlClient": SplitgraphGraphQLClient {
                   "graphqlClient": GraphQLClient {
                     "options": {

--- a/packages/core/splitgraph.test.ts
+++ b/packages/core/splitgraph.test.ts
@@ -75,24 +75,185 @@ describe("makeSplitgraphHTTPContext", () => {
               "ssl": true,
             },
           },
-          "plugins": {
-            "csv": _ImportCSVPlugin {
-              "graphqlClient": SplitgraphGraphQLClient {
-                "graphqlClient": GraphQLClient {
-                  "options": {
-                    "headers": [Function],
+          "opts": {
+            "authenticatedCredential": {
+              "anonymous": false,
+              "apiKey": "xxx",
+              "apiSecret": "yyy",
+            },
+            "database": {
+              "dbname": "ddn",
+            },
+            "host": {
+              "apexDomain": "splitgraph.com",
+              "apiHost": "api.splitgraph.com",
+              "baseUrls": {
+                "auth": "https://api.splitgraph.com/auth",
+                "gql": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                "sql": "https://data.splitgraph.com/sql/query",
+              },
+              "dataHost": "data.splitgraph.com",
+              "postgres": {
+                "host": "data.splitgraph.com",
+                "port": 5432,
+                "ssl": true,
+              },
+            },
+            "plugins": {
+              "exporters": {
+                "exportQuery": ExportQueryPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    },
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
                   },
-                  "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "transformRequestHeaders": [Function],
+                },
+              },
+              "importers": {
+                "csv": _ImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    },
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "transformRequestHeaders": [Function],
+                },
+                "mysql": _ImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    },
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "transformRequestHeaders": [Function],
+                },
+                "postgres": _ImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    },
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "transformRequestHeaders": [Function],
+                },
+              },
+            },
+          },
+          "plugins": {
+            "exporters": {
+              "exportQuery": ExportQueryPlugin {
+                "graphqlClient": SplitgraphGraphQLClient {
+                  "graphqlClient": GraphQLClient {
+                    "options": {
+                      "headers": [Function],
+                    },
+                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
                 },
                 "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                "opts": {
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
                 "transformRequestHeaders": [Function],
               },
-              "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-              "opts": {
+            },
+            "importers": {
+              "csv": _ImportCSVPlugin {
+                "graphqlClient": SplitgraphGraphQLClient {
+                  "graphqlClient": GraphQLClient {
+                    "options": {
+                      "headers": [Function],
+                    },
+                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
                 "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                "opts": {
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
                 "transformRequestHeaders": [Function],
               },
-              "transformRequestHeaders": [Function],
+              "mysql": _ImportCSVPlugin {
+                "graphqlClient": SplitgraphGraphQLClient {
+                  "graphqlClient": GraphQLClient {
+                    "options": {
+                      "headers": [Function],
+                    },
+                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
+                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                "opts": {
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
+                "transformRequestHeaders": [Function],
+              },
+              "postgres": _ImportCSVPlugin {
+                "graphqlClient": SplitgraphGraphQLClient {
+                  "graphqlClient": GraphQLClient {
+                    "options": {
+                      "headers": [Function],
+                    },
+                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
+                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                "opts": {
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
+                "transformRequestHeaders": [Function],
+              },
             },
           },
         },

--- a/packages/db-seafowl/db-seafowl.test.ts
+++ b/packages/db-seafowl/db-seafowl.test.ts
@@ -40,9 +40,12 @@ const createDb = () => {
       },
     },
     plugins: {
-      csv: new ImportCSVPlugin({
-        transformRequestHeaders,
-      }),
+      importers: {
+        csv: new ImportCSVPlugin({
+          transformRequestHeaders,
+        }),
+      },
+      exporters: {},
     },
   });
 };

--- a/packages/db-seafowl/db-seafowl.test.ts
+++ b/packages/db-seafowl/db-seafowl.test.ts
@@ -6,10 +6,19 @@ import { shouldSkipSeafowlTests } from "@madatdata/test-helpers/env-config";
 
 describe("importData", () => {
   it("returns false for unknown plugin", async () => {
+    let err: unknown;
     const db = makeDb({});
 
-    // @ts-expect-error not a key in SplitgraphPluginMap
-    const importResult = await db.importData("unknown-doesnotexist", {}, {});
+    await db
+      // @ts-expect-error typescript shouldn't allow using a plugin name not in map
+      .importData("unknown-doesnotexist", {}, {})
+      .catch((e) => {
+        err = e;
+      });
+
+    expect(err).toMatchInlineSnapshot(
+      "[Error: plugin not found: unknown-doesnotexist]"
+    );
   });
 });
 

--- a/packages/db-seafowl/db-seafowl.ts
+++ b/packages/db-seafowl/db-seafowl.ts
@@ -113,9 +113,10 @@ export class DbSeafowl extends BaseDb<OptionalPluginMap<SeafowlPluginMap>> {
     const [sourceOpts, destOpts] = rest;
 
     // TODO: temporarily hardcode the plugin map
-    const plugin = (
-      this.plugins["importers"] as ReturnType<typeof makeDefaultPluginMap>
-    )["importers"][pluginName];
+    const plugin = this.plugins.importers[pluginName];
+    if (!plugin) {
+      throw new Error(`plugin not found: ${pluginName}`);
+    }
 
     if (plugin) {
       return await plugin

--- a/packages/db-seafowl/plugins/importers/import-csv-seafowl-plugin.ts
+++ b/packages/db-seafowl/plugins/importers/import-csv-seafowl-plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "@madatdata/base-db";
+import type { ImportPlugin } from "@madatdata/base-db";
 import type { SeafowlDestOptions } from "./base-seafowl-import-plugin";
 
 interface ImportCSVDestOptions extends SeafowlDestOptions {
@@ -31,7 +31,7 @@ type ImportCSVSourceOptions =
 
 type DbInjectedOptions = Partial<ImportCSVPluginOptions>;
 
-export class ImportCSVPlugin implements Plugin {
+export class ImportCSVPlugin implements ImportPlugin {
   public readonly opts: ImportCSVPluginOptions;
   public readonly transformRequestHeaders: Required<ImportCSVPluginOptions>["transformRequestHeaders"];
 

--- a/packages/db-seafowl/plugins/importers/import-csv-seafowl-plugin.ts
+++ b/packages/db-seafowl/plugins/importers/import-csv-seafowl-plugin.ts
@@ -1,4 +1,4 @@
-import type { ImportPlugin } from "@madatdata/base-db";
+import type { ImportPlugin, WithOptionsInterface } from "@madatdata/base-db";
 import type { SeafowlDestOptions } from "./base-seafowl-import-plugin";
 
 interface ImportCSVDestOptions extends SeafowlDestOptions {
@@ -31,14 +31,19 @@ type ImportCSVSourceOptions =
 
 type DbInjectedOptions = Partial<ImportCSVPluginOptions>;
 
-export class ImportCSVPlugin implements ImportPlugin {
+export class ImportCSVPlugin
+  implements ImportPlugin, WithOptionsInterface<ImportCSVPlugin>
+{
   public readonly opts: ImportCSVPluginOptions;
   public readonly transformRequestHeaders: Required<ImportCSVPluginOptions>["transformRequestHeaders"];
+  public readonly graphqlEndpoint: string;
 
   constructor(opts: ImportCSVPluginOptions) {
     this.opts = opts;
 
     this.transformRequestHeaders = opts.transformRequestHeaders ?? IdentityFunc;
+
+    this.graphqlEndpoint = "http://todo.test/should-not-be-required-property";
   }
 
   // TODO: improve it (e.g. allow either mutation or copy), and/or generalize it

--- a/packages/db-seafowl/plugins/importers/index.ts
+++ b/packages/db-seafowl/plugins/importers/index.ts
@@ -1,9 +1,9 @@
-import type { Plugin } from "@madatdata/base-db";
+import type { ImportPlugin } from "@madatdata/base-db";
 
 type DEFAULT_PLUGINS = "csv";
 
 type DefaultPluginMap = {
-  [k in DEFAULT_PLUGINS]: Plugin;
+  [k in DEFAULT_PLUGINS]: ImportPlugin;
 };
 
 export type SeafowlImportPluginMap = DefaultPluginMap;

--- a/packages/db-seafowl/plugins/importers/index.ts
+++ b/packages/db-seafowl/plugins/importers/index.ts
@@ -1,9 +1,14 @@
 import type { ImportPlugin } from "@madatdata/base-db";
 
-type DEFAULT_PLUGINS = "csv";
+type DEFAULT_IMPORT_PLUGINS = "csv";
 
 type DefaultPluginMap = {
-  [k in DEFAULT_PLUGINS]: ImportPlugin;
+  importers: {
+    [k in DEFAULT_IMPORT_PLUGINS]: ImportPlugin;
+  };
+  exporters: {};
 };
 
-export type SeafowlImportPluginMap = DefaultPluginMap;
+export type SeafowlPluginMap = DefaultPluginMap;
+export type SeafowlExportPluginMap = SeafowlPluginMap["exporters"];
+export type SeafowlImportPluginMap = SeafowlPluginMap["importers"];

--- a/packages/db-splitgraph/.gitignore
+++ b/packages/db-splitgraph/.gitignore
@@ -2,4 +2,5 @@ plugins/importers/generated/*
 !plugins/importers/generated/.gitkeep
 gql-client/generated/*
 !gql-client/generated/.gitkeep
+!gql-client/generated/index.ts
 **/*.generated.ts

--- a/packages/db-splitgraph/codegen.yml
+++ b/packages/db-splitgraph/codegen.yml
@@ -10,6 +10,8 @@ config:
   #       (See file `base-documents-visitor.ts` for base config)
   strictScalars: true
   scalars:
+    # unified-schema.graphql includes custom scalar called Void to equal NULL
+    Void: "null"
     Datetime: "string"
     DateTime: "string"
     # FIXME: Splitgraph API has some inconsistent behavior

--- a/packages/db-splitgraph/codegen.yml
+++ b/packages/db-splitgraph/codegen.yml
@@ -59,7 +59,7 @@ generates:
       # Avoid needless intersection with { __typename: Query } on every Query
       skipTypeNameForRoot: true
     presetConfig:
-      baseTypesPath: "gql-client/generated/unified-schema"
+      baseTypesPath: "gql-client/unified-types.ts"
       extension: .generated.ts
       importTypesNamespace: Unified
     plugins:

--- a/packages/db-splitgraph/db-splitgraph.test.ts
+++ b/packages/db-splitgraph/db-splitgraph.test.ts
@@ -532,7 +532,7 @@ describe("importData for ImportCSVPlugin", () => {
 });
 
 // TODO WIP
-describe.skipIf(true)("real export query", () => {
+describe.only("real export query", () => {
   it.only("exports a basic postgres query to CSV", async () => {
     const db = createRealDb();
 
@@ -555,17 +555,30 @@ GROUP BY a ORDER BY a;`,
 
     expect({
       ...response,
-      taskId: response?.taskId ? "something-constant" : "something-wrong",
+      // filter out variable values from snapshot just by checking they exist
+      taskId: response?.taskId ? "task-id-ok" : "error-in-task-id",
+      started: response?.started ? "started-ok" : "error-in-started",
+      finished: response?.finished ? "finished-ok" : "error-id",
+      output: !!(response?.output as { url?: string })["url"]
+        ? { url: "url-ok" }
+        : { url: "error-in-url" },
     }).toMatchInlineSnapshot(`
       {
+        "exportFormat": "csv",
         "filename": "random-series.csv",
+        "finished": "finished-ok",
+        "output": {
+          "url": "url-ok",
+        },
+        "started": "started-ok",
+        "status": "SUCCESS",
         "success": true,
-        "taskId": "something-constant",
+        "taskId": "task-id-ok",
       }
     `);
 
     expect(error).toMatchInlineSnapshot("null");
-  });
+  }, 30_000);
 });
 
 describe.skipIf(shouldSkipIntegrationTests())("real DDN", () => {

--- a/packages/db-splitgraph/db-splitgraph.test.ts
+++ b/packages/db-splitgraph/db-splitgraph.test.ts
@@ -531,9 +531,9 @@ describe("importData for ImportCSVPlugin", () => {
   });
 });
 
-// TODO WIP
-describe.only("real export query", () => {
-  it.only("exports a basic postgres query to CSV", async () => {
+// TODO: Make a mocked version of this test
+describe.skipIf(shouldSkipIntegrationTests())("real export query", () => {
+  it("exports a basic postgres query to CSV", async () => {
     const db = createRealDb();
 
     const { response, error, info } = await db.exportData(
@@ -552,6 +552,10 @@ GROUP BY a ORDER BY a;`,
 
     expect(response).toBeDefined();
     expect(info).toBeDefined();
+
+    expect(response?.output.url).toBeDefined();
+
+    expect(() => new URL(response?.output.url!)).not.toThrow();
 
     expect({
       ...response,

--- a/packages/db-splitgraph/db-splitgraph.test.ts
+++ b/packages/db-splitgraph/db-splitgraph.test.ts
@@ -33,10 +33,13 @@ const createDb = () => {
       anonymous: false,
     },
     plugins: {
-      csv: new ImportCSVPlugin({
-        graphqlEndpoint: defaultHost.baseUrls.gql,
-        transformRequestHeaders,
-      }),
+      importers: {
+        csv: new ImportCSVPlugin({
+          graphqlEndpoint: defaultHost.baseUrls.gql,
+          transformRequestHeaders,
+        }),
+      },
+      exporters: {},
     },
   });
 };
@@ -63,9 +66,12 @@ const createRealDb = () => {
       anonymous: false,
     },
     plugins: {
-      csv: new ImportCSVPlugin({
-        graphqlEndpoint: defaultHost.baseUrls.gql,
-      }),
+      importers: {
+        csv: new ImportCSVPlugin({
+          graphqlEndpoint: defaultHost.baseUrls.gql,
+        }),
+      },
+      exporters: {},
     },
   });
 };

--- a/packages/db-splitgraph/db-splitgraph.ts
+++ b/packages/db-splitgraph/db-splitgraph.ts
@@ -31,6 +31,8 @@ const makeDefaultPluginMap = (opts: {
           }
         : reqHeaders,
   }),
+
+  // exportQueryResult:
 });
 
 export class DbSplitgraph extends BaseDb<Partial<SplitgraphImportPluginMap>> {

--- a/packages/db-splitgraph/db-splitgraph.ts
+++ b/packages/db-splitgraph/db-splitgraph.ts
@@ -207,7 +207,7 @@ export class DbSplitgraph extends BaseDb<
   async exportData<PluginName extends keyof SplitgraphExportPluginMap>(
     pluginName: PluginName,
     ...rest: Parameters<SplitgraphExportPluginMap[PluginName]["exportData"]>
-  ): Promise<unknown> {
+  ) {
     const [sourceOpts, destOpts] = rest;
 
     const plugin = this.plugins.exporters[pluginName];

--- a/packages/db-splitgraph/gql-client/explicit-types.ts
+++ b/packages/db-splitgraph/gql-client/explicit-types.ts
@@ -1,0 +1,11 @@
+// Manually-defined types, e.g. adding fields to some JSON value
+
+/**
+ * A typed version of the JSON field in ExportJobStatus.output
+ */
+export interface ExportJobOutput {
+  /**
+   * The URL of the file where the output artifact can be downloaded
+   */
+  url: string;
+}

--- a/packages/db-splitgraph/gql-client/unified-types.ts
+++ b/packages/db-splitgraph/gql-client/unified-types.ts
@@ -1,0 +1,6 @@
+// This is the root file which is imported by every .generated.ts GraphQL file
+// e.g.: import type * as Unified from "../gql-client/unified-types";
+// We don't name it types.ts because it only refers to API types (not client-only local code)
+
+export * from "./generated/unified-schema";
+export * from "./explicit-types";

--- a/packages/db-splitgraph/package.json
+++ b/packages/db-splitgraph/package.json
@@ -99,7 +99,7 @@
         "!build",
         "!.wireit"
       ],
-      "clean": "if-file-deleted"
+      "clean": true
     },
     "fetch-remote-graphql-schema": {
       "//": "this command should be run once or out of band, so no dependencies",

--- a/packages/db-splitgraph/package.json
+++ b/packages/db-splitgraph/package.json
@@ -104,7 +104,9 @@
     "fetch-remote-graphql-schema": {
       "//": "this command should be run once or out of band, so no dependencies",
       "command": "DEBUG=1 VERBOSE=1 yarn graphql-codegen --config codegen.schema.yml",
-      "output": [],
+      "output": [
+        "gql-client/generated/unified-schema.graphql"
+      ],
       "packageLocks": [],
       "files": []
     }

--- a/packages/db-splitgraph/plugins/exporters/export-query-plugin.ts
+++ b/packages/db-splitgraph/plugins/exporters/export-query-plugin.ts
@@ -1,0 +1,54 @@
+import type { ExportPlugin } from "@madatdata/base-db";
+
+// import { gql } from "graphql-request";
+
+type ExportQuerySourceOptions = {
+  /**
+   * The raw SQL query for which to export the result
+   */
+  query: string;
+  /**
+   * Run export in the context of vdb with this vdbId (default: ddn)
+   */
+  vdbId?: string;
+};
+
+type ExportQueryDestOptions = {
+  format: "csv" | "parquet";
+  filename?: string;
+};
+
+// from unified spec
+// type _ExportJobStatus = "status" | "finished" | "output" | "started";
+
+interface ExportQueryPluginOptions {
+  graphqlEndpoint: string;
+  transformRequestHeaders?: (requestHeaders: HeadersInit) => HeadersInit;
+}
+
+export class ExportQueryPlugin implements ExportPlugin {
+  private readonly opts: ExportQueryPluginOptions;
+
+  constructor(opts: ExportQueryPluginOptions) {
+    this.opts = opts;
+  }
+
+  async exportData(
+    _sourceOptions: ExportQuerySourceOptions,
+    _destOptions: ExportQueryDestOptions
+  ) {
+    console.log("exportData");
+    console.log("opts:", this.opts);
+    await Promise.resolve();
+
+    return {
+      response: {
+        success: true,
+      },
+      error: null,
+      info: {
+        jobStatus: "finished",
+      },
+    };
+  }
+}

--- a/packages/db-splitgraph/plugins/importers/import-csv-plugin.ts
+++ b/packages/db-splitgraph/plugins/importers/import-csv-plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "@madatdata/base-db";
+import type { ImportPlugin } from "@madatdata/base-db";
 import type { SplitgraphDestOptions } from "./base-import-plugin";
 
 import { gql } from "graphql-request";
@@ -75,7 +75,7 @@ const retryOptions = {
   backOffPolicy: BackOffPolicy.ExponentialBackOffPolicy,
   exponentialOption: { maxInterval: MAX_BACKOFF_INTERVAL, multiplier: 2 },
 };
-export class ImportCSVPlugin implements Plugin {
+export class ImportCSVPlugin implements ImportPlugin {
   public readonly opts: ImportCSVPluginOptions;
   public readonly graphqlEndpoint: ImportCSVPluginOptions["graphqlEndpoint"];
   public readonly graphqlClient: SplitgraphGraphQLClient;

--- a/packages/db-splitgraph/plugins/importers/import-csv-plugin.ts
+++ b/packages/db-splitgraph/plugins/importers/import-csv-plugin.ts
@@ -18,8 +18,6 @@ import type {
   StartExternalRepositoryLoadMutationVariables,
 } from "./import-csv-plugin.generated";
 
-// something
-
 interface ImportCSVDestOptions extends SplitgraphDestOptions {
   params?: CsvParamsSchema;
   tableName: SplitgraphDestOptions["tableName"];
@@ -419,8 +417,6 @@ export class ImportCSVPlugin
       repository,
     }: Pick<ImportCSVDestOptions, "namespace" | "repository">
   ) {
-    console.log(new Date().toLocaleTimeString(), "waitFor:", taskId);
-
     const {
       response: jobStatusResponse,
       error: jobStatusError,

--- a/packages/db-splitgraph/plugins/importers/import-csv-plugin.ts
+++ b/packages/db-splitgraph/plugins/importers/import-csv-plugin.ts
@@ -1,4 +1,4 @@
-import type { ImportPlugin } from "@madatdata/base-db";
+import type { ImportPlugin, WithOptionsInterface } from "@madatdata/base-db";
 import type { SplitgraphDestOptions } from "./base-import-plugin";
 
 import { gql } from "graphql-request";
@@ -75,7 +75,10 @@ const retryOptions = {
   backOffPolicy: BackOffPolicy.ExponentialBackOffPolicy,
   exponentialOption: { maxInterval: MAX_BACKOFF_INTERVAL, multiplier: 2 },
 };
-export class ImportCSVPlugin implements ImportPlugin {
+
+export class ImportCSVPlugin
+  implements ImportPlugin, WithOptionsInterface<ImportCSVPlugin>
+{
   public readonly opts: ImportCSVPluginOptions;
   public readonly graphqlEndpoint: ImportCSVPluginOptions["graphqlEndpoint"];
   public readonly graphqlClient: SplitgraphGraphQLClient;

--- a/packages/db-splitgraph/plugins/importers/index.ts
+++ b/packages/db-splitgraph/plugins/importers/index.ts
@@ -1,5 +1,5 @@
 import type { ImportCSVPlugin } from "./import-csv-plugin";
-import type { ExportPlugin, ImportPlugin } from "@madatdata/base-db";
+import type { /*ExportPlugin,*/ ImportPlugin } from "@madatdata/base-db";
 import type { ExportQueryPlugin } from "../exporters/export-query-plugin";
 
 // NOTE: In theory this will be auto-generated
@@ -13,11 +13,9 @@ export type SplitgraphPluginMap = {
   } & {
     [k in keyof SPECIAL_IMPORT_PLUGINS]: SPECIAL_IMPORT_PLUGINS[k];
   };
-  exporters:
-    | {
-        exportQuery: ExportQueryPlugin;
-      }
-    | Record<string, ExportPlugin>;
+  exporters: {
+    exportQuery: ExportQueryPlugin;
+  };
 };
 
 export type SplitgraphImportPluginMap = SplitgraphPluginMap["importers"];

--- a/packages/db-splitgraph/plugins/importers/index.ts
+++ b/packages/db-splitgraph/plugins/importers/index.ts
@@ -1,5 +1,5 @@
 import type { ImportCSVPlugin } from "./import-csv-plugin";
-import type { Plugin } from "@madatdata/base-db";
+import type { ImportPlugin } from "@madatdata/base-db";
 
 // NOTE: In theory this will be auto-generated
 type DEFAULT_PLUGINS = "mysql" | "postgres";
@@ -13,7 +13,7 @@ type SpecialPluginMap = {
 };
 
 type DefaultPluginMap = {
-  [k in DEFAULT_PLUGINS]: Plugin;
+  [k in DEFAULT_PLUGINS]: ImportPlugin;
 };
 
 export type SplitgraphImportPluginMap = DefaultPluginMap & SpecialPluginMap;

--- a/packages/db-splitgraph/plugins/importers/index.ts
+++ b/packages/db-splitgraph/plugins/importers/index.ts
@@ -1,19 +1,24 @@
 import type { ImportCSVPlugin } from "./import-csv-plugin";
-import type { ImportPlugin } from "@madatdata/base-db";
+import type { ExportPlugin, ImportPlugin } from "@madatdata/base-db";
+import type { ExportQueryPlugin } from "../exporters/export-query-plugin";
 
 // NOTE: In theory this will be auto-generated
-type DEFAULT_PLUGINS = "mysql" | "postgres";
-
-type SPECIAL_PLUGINS = {
+type DEFAULT_IMPORT_PLUGINS = "mysql" | "postgres";
+type SPECIAL_IMPORT_PLUGINS = {
   csv: ImportCSVPlugin;
 };
-
-type SpecialPluginMap = {
-  [k in keyof SPECIAL_PLUGINS]: SPECIAL_PLUGINS[k];
+export type SplitgraphPluginMap = {
+  importers: {
+    [k in DEFAULT_IMPORT_PLUGINS]: ImportPlugin;
+  } & {
+    [k in keyof SPECIAL_IMPORT_PLUGINS]: SPECIAL_IMPORT_PLUGINS[k];
+  };
+  exporters:
+    | {
+        exportQuery: ExportQueryPlugin;
+      }
+    | Record<string, ExportPlugin>;
 };
 
-type DefaultPluginMap = {
-  [k in DEFAULT_PLUGINS]: ImportPlugin;
-};
-
-export type SplitgraphImportPluginMap = DefaultPluginMap & SpecialPluginMap;
+export type SplitgraphImportPluginMap = SplitgraphPluginMap["importers"];
+export type SplitgraphExportPluginMap = SplitgraphPluginMap["exporters"];

--- a/packages/db-splitgraph/plugins/index.ts
+++ b/packages/db-splitgraph/plugins/index.ts
@@ -1,1 +1,6 @@
 export * from "./importers";
+
+export interface GraphQLClientOptions {
+  graphqlEndpoint: string;
+  transformRequestHeaders?: (requestHeaders: HeadersInit) => HeadersInit;
+}

--- a/packages/react/hooks.test.tsx
+++ b/packages/react/hooks.test.tsx
@@ -200,7 +200,7 @@ describe("makeDefaultAnonymousContext", () => {
             },
             "plugins": {
               "exporters": {
-                "exportQuery": ExportQueryPlugin {
+                "exportQuery": _ExportQueryPlugin {
                   "graphqlClient": SplitgraphGraphQLClient {
                     "graphqlClient": GraphQLClient {
                       "options": {
@@ -279,7 +279,7 @@ describe("makeDefaultAnonymousContext", () => {
           },
           "plugins": {
             "exporters": {
-              "exportQuery": ExportQueryPlugin {
+              "exportQuery": _ExportQueryPlugin {
                 "graphqlClient": SplitgraphGraphQLClient {
                   "graphqlClient": GraphQLClient {
                     "options": {

--- a/packages/react/hooks.test.tsx
+++ b/packages/react/hooks.test.tsx
@@ -178,24 +178,181 @@ describe("makeDefaultAnonymousContext", () => {
               "ssl": true,
             },
           },
-          "plugins": {
-            "csv": _ImportCSVPlugin {
-              "graphqlClient": SplitgraphGraphQLClient {
-                "graphqlClient": GraphQLClient {
-                  "options": {
-                    "headers": [Function],
+          "opts": {
+            "authenticatedCredential": undefined,
+            "database": {
+              "dbname": "ddn",
+            },
+            "host": {
+              "apexDomain": "splitgraph.com",
+              "apiHost": "api.splitgraph.com",
+              "baseUrls": {
+                "auth": "https://api.splitgraph.com/auth",
+                "gql": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                "sql": "https://data.splitgraph.com/sql/query",
+              },
+              "dataHost": "data.splitgraph.com",
+              "postgres": {
+                "host": "data.splitgraph.com",
+                "port": 5432,
+                "ssl": true,
+              },
+            },
+            "plugins": {
+              "exporters": {
+                "exportQuery": ExportQueryPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    },
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
                   },
-                  "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "transformRequestHeaders": [Function],
+                },
+              },
+              "importers": {
+                "csv": _ImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    },
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "transformRequestHeaders": [Function],
+                },
+                "mysql": _ImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    },
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "transformRequestHeaders": [Function],
+                },
+                "postgres": _ImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    },
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
+                  "transformRequestHeaders": [Function],
+                },
+              },
+            },
+          },
+          "plugins": {
+            "exporters": {
+              "exportQuery": ExportQueryPlugin {
+                "graphqlClient": SplitgraphGraphQLClient {
+                  "graphqlClient": GraphQLClient {
+                    "options": {
+                      "headers": [Function],
+                    },
+                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
                 },
                 "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                "opts": {
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
                 "transformRequestHeaders": [Function],
               },
-              "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-              "opts": {
+            },
+            "importers": {
+              "csv": _ImportCSVPlugin {
+                "graphqlClient": SplitgraphGraphQLClient {
+                  "graphqlClient": GraphQLClient {
+                    "options": {
+                      "headers": [Function],
+                    },
+                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
                 "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                "opts": {
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
                 "transformRequestHeaders": [Function],
               },
-              "transformRequestHeaders": [Function],
+              "mysql": _ImportCSVPlugin {
+                "graphqlClient": SplitgraphGraphQLClient {
+                  "graphqlClient": GraphQLClient {
+                    "options": {
+                      "headers": [Function],
+                    },
+                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
+                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                "opts": {
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
+                "transformRequestHeaders": [Function],
+              },
+              "postgres": _ImportCSVPlugin {
+                "graphqlClient": SplitgraphGraphQLClient {
+                  "graphqlClient": GraphQLClient {
+                    "options": {
+                      "headers": [Function],
+                    },
+                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  },
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
+                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                "opts": {
+                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "transformRequestHeaders": [Function],
+                },
+                "transformRequestHeaders": [Function],
+              },
             },
           },
         },

--- a/packages/test-helpers/env-config.ts
+++ b/packages/test-helpers/env-config.ts
@@ -65,5 +65,5 @@ export const shouldSkipIntegrationTests = () => {
 export const shouldSkipSeafowlTests = () => {
   // TEMP: true for commit in CI (uncomment for local dev)
   // (because there is no seafowl setup in CI yet)
-  return true;
+  return false;
 };

--- a/packages/test-helpers/env-config.ts
+++ b/packages/test-helpers/env-config.ts
@@ -65,5 +65,5 @@ export const shouldSkipIntegrationTests = () => {
 export const shouldSkipSeafowlTests = () => {
   // TEMP: true for commit in CI (uncomment for local dev)
   // (because there is no seafowl setup in CI yet)
-  return false;
+  return true;
 };


### PR DESCRIPTION
This is the minimal code required for exporters to work, e.g. 

```ts
const { response, error, info } = await db.exportData(
      "exportQuery",
      {
        query: `SELECT a as int_val, string_agg(random()::text, '') as text_val
FROM generate_series(1, 5) a, generate_series(1, 50) b
GROUP BY a ORDER BY a;`,
        vdbId: "ddn",
      },
      {
        format: "csv",
        filename: "random-series",
      }
    );
```

This submits the export job, waits for its taskId, and then returns with an object including the `output` of the job, which contains the `url` (`response.output.url` in the above example). This does not actually download the file at the URL. That may be desired at some point, but for now the goal is to export a Parquet file from Splitgraph and import it into a Seafowl table. Since Seafowl can create a table from a URL to a remote CSV, there is no need to download the file.

This PR also does not include the new/upcoming exportFormat `sync` feature, for direct Splitgraph to Seafowl sync (coordinated by Splitgraph, rather than by e.g. this library manually orchestrating its own export and import between `db-splitgraph` and `db-seafowl`).

Also in this PR is a refactoring of the `PluginMap` type, to include both `importers` (plugins which define `importData`) and `exporters` (plugins which define `exportData`). More thought is required here. For now I just copied conventions from `import-csv-plugin` and noted where the code needs to DRY out.

Example of current plugin system ergonomics  (from `db-splitgraph.test.ts`):

```ts
makeDb({
    authenticatedCredential: {
      apiKey: credential.apiKey,
      apiSecret: credential.apiSecret,
      anonymous: false,
    },
    plugins: {
      importers: {
        csv: new ImportCSVPlugin({
          graphqlEndpoint: defaultHost.baseUrls.gql,
        }),
      },
      exporters: {
        exportQuery: new ExportQueryPlugin({
          graphqlEndpoint: defaultHost.baseUrls.gql,
        }),
      },
    },
  });
```