### PR TITLE
Add `SeafowlImportFile` plugin (implements `DbSeafowl.importData`), begin refactor of plugin architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ so create a file `.env.integration.local` to hold any env keys:
 VITE_TEST_INTEGRATION=1
 VITE_TEST_DDN_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 VITE_TEST_DDN_API_SECRET=yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+VITE_TEST_SEAFOWL_SECRET=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
 ```
 
 Then simply append `--mode integration` flag to any variant of `yarn test` that

--- a/packages/base-db/base-db.ts
+++ b/packages/base-db/base-db.ts
@@ -66,7 +66,7 @@ export abstract class BaseDb<
           ...opts?.plugins.exporters,
         },
       },
-      {}
+      {} as PluginHostContext
     );
     this.opts = opts;
   }

--- a/packages/base-db/base-db.ts
+++ b/packages/base-db/base-db.ts
@@ -114,7 +114,7 @@ export abstract class BaseDb<ConcretePluginMap extends PluginMap>
     normalizeQuery: (sql: string) => string = this.normalizeQueryForHTTPHeader
   ) {
     // In a browser, window.webcrypto.subtle should be available
-    // In node, we need to use the import from the ambient node: module
+    // In node, we (used to need?) to use the import from the ambient node: module
     // In vitest, really JSDOM, it's a bit of a mix between the two (window is available?)
     // NOTE: Need to test how this will work in a browser bundle which we don't even have yet
     const subtle = (() => {

--- a/packages/base-db/base-db.ts
+++ b/packages/base-db/base-db.ts
@@ -83,11 +83,13 @@ export abstract class BaseDb<
     }
   }
 
-  public makeClient<ImplementationSpecificClientOptions>(
+  public makeClient<ImplementationSpecificClientOptions, Strategies>(
     makeClientForProtocol: (
-      wrappedOptions: ImplementationSpecificClientOptions & ClientOptions
+      wrappedOptions: ImplementationSpecificClientOptions &
+        ClientOptions<Strategies>
     ) => Client,
-    clientOptions: ImplementationSpecificClientOptions & ClientOptions
+    clientOptions: ImplementationSpecificClientOptions &
+      ClientOptions<Strategies>
   ) {
     return makeClientForProtocol({
       database: this.database,

--- a/packages/base-db/index.ts
+++ b/packages/base-db/index.ts
@@ -1,3 +1,5 @@
 export * from "./plugin-bindings";
 
 export { type Db, BaseDb, type DbOptions } from "./base-db";
+
+export { type WithPluginRegistry, PluginRegistry } from "./plugin-registry";

--- a/packages/base-db/plugin-bindings.ts
+++ b/packages/base-db/plugin-bindings.ts
@@ -51,6 +51,10 @@ export interface WithOptionsInterface<ClassT> {
   withOptions: WithOptions<ClassT>;
 }
 
+export interface WithPlugins<ConcretePluginMap extends PluginMap> {
+  plugins: OptionalPluginMap<ConcretePluginMap>;
+}
+
 export interface BasePlugin {
   // importData: <
   //   SourceOptions extends Record<PropertyKey, unknown>,

--- a/packages/base-db/plugin-bindings.ts
+++ b/packages/base-db/plugin-bindings.ts
@@ -10,6 +10,11 @@ type PluginMapShape = {
   exporters: Record<string, ExportPlugin>;
 };
 
+type OptionalPluginMapShape = {
+  importers: Record<string, ImportPlugin | undefined>;
+  exporters: Record<string, ExportPlugin | undefined>;
+};
+
 export type PluginMap<
   ConcretePluginMap extends PluginMapShape = {
     importers: PluginMapShape["importers"];
@@ -29,15 +34,13 @@ export type PluginMap<
 };
 
 export type OptionalPluginMap<
-  ConcretePluginMap extends PluginMapShape = {
-    importers: Record<string, ImportPlugin>;
-    exporters: Record<string, ExportPlugin>;
-  },
-  Importers = PluginMap<ConcretePluginMap>["importers"],
-  Exporters = PluginMap<ConcretePluginMap>["exporters"]
+  ConcretePluginMap extends OptionalPluginMapShape = {
+    importers: OptionalPluginMapShape["importers"];
+    exporters: OptionalPluginMapShape["exporters"];
+  }
 > = {
-  importers: Partial<Importers>;
-  exporters: Partial<Exporters>;
+  importers: Partial<ConcretePluginMap["importers"]>;
+  exporters: Partial<ConcretePluginMap["exporters"]>;
 };
 
 export type WithOptions<OuterClassT> = <

--- a/packages/base-db/plugin-bindings.ts
+++ b/packages/base-db/plugin-bindings.ts
@@ -17,12 +17,12 @@ export type PluginMap<
   }
 > = {
   importers: {
-    [pluginName in keyof ConcretePluginMap["importers"]]: ConcretePluginMap["importers"] extends never
+    [pluginName in keyof ConcretePluginMap["importers"]]: ConcretePluginMap["importers"][pluginName] extends never
       ? ImportPlugin
       : ConcretePluginMap["importers"][pluginName];
   };
   exporters: {
-    [pluginName in keyof ConcretePluginMap["exporters"]]: ConcretePluginMap["exporters"] extends never
+    [pluginName in keyof ConcretePluginMap["exporters"]]: ConcretePluginMap["exporters"][pluginName] extends never
       ? ExportPlugin
       : ConcretePluginMap["exporters"][pluginName];
   };
@@ -30,8 +30,8 @@ export type PluginMap<
 
 export type OptionalPluginMap<
   ConcretePluginMap extends PluginMapShape = {
-    importers: any;
-    exporters: any;
+    importers: Record<string, ImportPlugin>;
+    exporters: Record<string, ExportPlugin>;
   },
   Importers = PluginMap<ConcretePluginMap>["importers"],
   Exporters = PluginMap<ConcretePluginMap>["exporters"]
@@ -49,10 +49,6 @@ export type WithOptions<OuterClassT> = <
 
 export interface WithOptionsInterface<ClassT> {
   withOptions: WithOptions<ClassT>;
-}
-
-export interface WithPlugins<ConcretePluginMap extends PluginMap> {
-  plugins: OptionalPluginMap<ConcretePluginMap>;
 }
 
 export interface BasePlugin {

--- a/packages/base-db/plugin-bindings.ts
+++ b/packages/base-db/plugin-bindings.ts
@@ -64,7 +64,7 @@ export interface BasePlugin {
 
   __name?: string;
 
-  graphqlEndpoint: string;
+  graphqlEndpoint?: string;
 }
 
 // export abstract class

--- a/packages/base-db/plugin-registry.ts
+++ b/packages/base-db/plugin-registry.ts
@@ -1,0 +1,81 @@
+import type { OptionalPluginMap, PluginMap } from "./plugin-bindings";
+
+export interface WithPluginRegistry<
+  ConcretePluginMap extends PluginMap,
+  PluginHostContext extends object
+> {
+  plugins: PluginRegistry<ConcretePluginMap, PluginHostContext>;
+}
+
+export class PluginRegistry<
+  ConcretePluginMap extends PluginMap,
+  PluginHostContext extends object
+> implements PluginMap
+{
+  public plugins: OptionalPluginMap<ConcretePluginMap>;
+
+  constructor(
+    plugins: OptionalPluginMap<ConcretePluginMap>,
+    { helpers: _helpers }: { helpers?: any }
+  ) {
+    this.plugins = registerPlugins<ConcretePluginMap, PluginHostContext>(
+      this,
+      plugins
+    );
+
+    // const _importers = Object.entries(this.plugins.importers).map(
+    //   ([_, v]) => v
+    // );
+  }
+
+  public get importers(): PluginMap["importers"] {
+    const rval = Object.entries(this.plugins.importers)
+      .filter(([_, plugin]) => plugin.importData)
+      .reduce(
+        (acc, [pluginName, plugin]) => ({
+          ...acc,
+          [pluginName]: plugin,
+        }),
+        {}
+      );
+
+    return rval;
+
+    // for (const [pluginName, plugin] of Object.entries(this.plugins.importers)) {
+    // }
+  }
+
+  public get exporters(): PluginMap["exporters"] {
+    const rval = Object.entries(this.plugins.exporters)
+      .filter(([_, plugin]) => plugin.exportData)
+      .reduce(
+        (acc, [pluginName, plugin]) => ({
+          ...acc,
+          [pluginName]: plugin,
+        }),
+        {}
+      );
+    return rval;
+  }
+
+  public get helpers() {
+    return;
+  }
+}
+
+const registerPlugins = <
+  ConcretePluginMap extends PluginMap,
+  PluginHostContext extends object
+>(
+  _pluginRegistry: PluginRegistry<ConcretePluginMap, PluginHostContext>,
+  pluginMap: OptionalPluginMap<ConcretePluginMap>
+) => {
+  return {
+    importers: {
+      ...pluginMap.importers,
+    },
+    exporters: {
+      ...pluginMap.exporters,
+    },
+  };
+};

--- a/packages/base-db/plugin-registry.ts
+++ b/packages/base-db/plugin-registry.ts
@@ -10,52 +10,50 @@ export interface WithPluginRegistry<
 export class PluginRegistry<
   ConcretePluginMap extends PluginMap,
   PluginHostContext extends object
-> implements PluginMap
+> implements OptionalPluginMap<ConcretePluginMap>
 {
   public plugins: OptionalPluginMap<ConcretePluginMap>;
+  public hostContext: PluginHostContext;
 
   constructor(
     plugins: OptionalPluginMap<ConcretePluginMap>,
-    { helpers: _helpers }: { helpers?: any }
+    hostContext: PluginHostContext
   ) {
     this.plugins = registerPlugins<ConcretePluginMap, PluginHostContext>(
       this,
       plugins
     );
 
-    // const _importers = Object.entries(this.plugins.importers).map(
-    //   ([_, v]) => v
-    // );
+    this.hostContext = hostContext;
   }
 
-  public get importers(): PluginMap["importers"] {
-    const rval = Object.entries(this.plugins.importers)
-      .filter(([_, plugin]) => plugin.importData)
-      .reduce(
-        (acc, [pluginName, plugin]) => ({
-          ...acc,
-          [pluginName]: plugin,
-        }),
-        {}
-      );
+  public get importers(): OptionalPluginMap<ConcretePluginMap>["importers"] {
+    const pluginsWithImportDataMethod: OptionalPluginMap<ConcretePluginMap>["importers"] =
+      Object.entries(this.plugins.importers)
+        .filter(([_, plugin]) => plugin.importData)
+        .reduce(
+          (acc, [pluginName, plugin]) => ({
+            ...acc,
+            [pluginName]: plugin,
+          }),
+          {}
+        );
 
-    return rval;
-
-    // for (const [pluginName, plugin] of Object.entries(this.plugins.importers)) {
-    // }
+    return pluginsWithImportDataMethod;
   }
 
-  public get exporters(): PluginMap["exporters"] {
-    const rval = Object.entries(this.plugins.exporters)
-      .filter(([_, plugin]) => plugin.exportData)
-      .reduce(
-        (acc, [pluginName, plugin]) => ({
-          ...acc,
-          [pluginName]: plugin,
-        }),
-        {}
-      );
-    return rval;
+  public get exporters(): OptionalPluginMap<ConcretePluginMap>["exporters"] {
+    const pluginsWithExportDataMethod: OptionalPluginMap<ConcretePluginMap>["exporters"] =
+      Object.entries(this.plugins.exporters)
+        .filter(([_, plugin]) => plugin.exportData)
+        .reduce(
+          (acc, [pluginName, plugin]) => ({
+            ...acc,
+            [pluginName]: plugin,
+          }),
+          {}
+        );
+    return pluginsWithExportDataMethod;
   }
 
   public get helpers() {
@@ -69,7 +67,7 @@ const registerPlugins = <
 >(
   _pluginRegistry: PluginRegistry<ConcretePluginMap, PluginHostContext>,
   pluginMap: OptionalPluginMap<ConcretePluginMap>
-) => {
+): OptionalPluginMap<ConcretePluginMap> => {
   return {
     importers: {
       ...pluginMap.importers,

--- a/packages/core/data-context.ts
+++ b/packages/core/data-context.ts
@@ -2,7 +2,7 @@ import type { Client } from "@madatdata/base-client";
 import type { BaseDb } from "@madatdata/base-db";
 
 export interface DataContext<
-  Db extends BaseDb<{ importers: {}; exporters: {} }>
+  Db extends BaseDb<{ importers: {}; exporters: {} }, {}>
 > {
   client: Client;
   db: Db;

--- a/packages/core/seafowl.test.ts
+++ b/packages/core/seafowl.test.ts
@@ -185,12 +185,14 @@ describe("makeSeafowlHTTPContext", () => {
               },
             },
           },
-          "plugins": {
-            "exporters": {},
-            "importers": {
-              "csv": SeafowlImportFilePlugin {
-                "opts": {
-                  "seafowlClient": undefined,
+          "plugins": PluginRegistry {
+            "plugins": {
+              "exporters": {},
+              "importers": {
+                "csv": SeafowlImportFilePlugin {
+                  "opts": {
+                    "seafowlClient": undefined,
+                  },
                 },
               },
             },

--- a/packages/core/seafowl.test.ts
+++ b/packages/core/seafowl.test.ts
@@ -2,18 +2,50 @@ import { describe, it, expect } from "vitest";
 
 import { makeSeafowlHTTPContext } from "./seafowl";
 import { setupMswServerTestHooks } from "@madatdata/test-helpers/msw-server-hooks";
-import { shouldSkipSeafowlTests } from "@madatdata/test-helpers/env-config";
+import {
+  shouldSkipIntegrationTests,
+  shouldSkipSeafowlTests,
+} from "@madatdata/test-helpers/env-config";
 
 // @ts-expect-error https://stackoverflow.com/a/70711231
 const SEAFOWL_SECRET = import.meta.env.VITE_TEST_SEAFOWL_SECRET;
 
-const createDataContext = () => {
+export const createDataContext = () => {
   return makeSeafowlHTTPContext({
     database: {
       dbname: "seafowl", // arbitrary
     },
     authenticatedCredential: {
       token: SEAFOWL_SECRET,
+      anonymous: false,
+    },
+    host: {
+      // temporary hacky mess
+      dataHost: "127.0.0.1:8080",
+      apexDomain: "bogus",
+      apiHost: "bogus",
+      baseUrls: {
+        gql: "bogus",
+        sql: "http://127.0.0.1:8080/q",
+        auth: "bogus",
+      },
+      postgres: {
+        host: "127.0.0.1",
+        port: 6432,
+        ssl: false,
+      },
+    },
+  });
+};
+
+export const createRealDataContext = () => {
+  return makeSeafowlHTTPContext({
+    database: {
+      dbname: "seafowl", // arbitrary
+    },
+    authenticatedCredential: {
+      // @ts-expect-error https://stackoverflow.com/a/70711231
+      token: import.meta.env.VITE_TEST_SEAFOWL_SECRET,
       anonymous: false,
     },
     host: {
@@ -177,4 +209,11 @@ describe.skipIf(shouldSkipSeafowlTests())("can query local seafowl", () => {
       }
     `);
   });
+
+  it.skipIf(shouldSkipIntegrationTests())(
+    "can export data from splitrgaph, import it into seafowl",
+    async () => {
+      const { db } = createDataContext();
+    }
+  );
 });

--- a/packages/core/seafowl.test.ts
+++ b/packages/core/seafowl.test.ts
@@ -4,10 +4,17 @@ import { makeSeafowlHTTPContext } from "./seafowl";
 import { setupMswServerTestHooks } from "@madatdata/test-helpers/msw-server-hooks";
 import { shouldSkipSeafowlTests } from "@madatdata/test-helpers/env-config";
 
+// @ts-expect-error https://stackoverflow.com/a/70711231
+const SEAFOWL_SECRET = import.meta.env.VITE_TEST_SEAFOWL_SECRET;
+
 const createDataContext = () => {
   return makeSeafowlHTTPContext({
     database: {
       dbname: "seafowl", // arbitrary
+    },
+    authenticatedCredential: {
+      token: SEAFOWL_SECRET,
+      anonymous: false,
     },
     host: {
       // temporary hacky mess
@@ -42,8 +49,8 @@ describe("makeSeafowlHTTPContext", () => {
         "client": SqlHTTPClient {
           "bodyMode": "jsonl",
           "credential": {
-            "anonymous": true,
-            "token": "anonymous-token",
+            "anonymous": false,
+            "token": "${SEAFOWL_SECRET}",
           },
           "database": {
             "dbname": "seafowl",
@@ -69,6 +76,10 @@ describe("makeSeafowlHTTPContext", () => {
           },
         },
         "db": DbSeafowl {
+          "authenticatedCredential": {
+            "anonymous": false,
+            "token": "${SEAFOWL_SECRET}",
+          },
           "database": {
             "dbname": "seafowl",
           },
@@ -88,7 +99,10 @@ describe("makeSeafowlHTTPContext", () => {
             },
           },
           "opts": {
-            "authenticatedCredential": undefined,
+            "authenticatedCredential": {
+              "anonymous": false,
+              "token": "${SEAFOWL_SECRET}",
+            },
             "database": {
               "dbname": "seafowl",
             },

--- a/packages/core/seafowl.test.ts
+++ b/packages/core/seafowl.test.ts
@@ -177,7 +177,7 @@ describe("makeSeafowlHTTPContext", () => {
             "plugins": {
               "exporters": {},
               "importers": {
-                "csv": ImportCSVPlugin {
+                "csv": SeafowlImportFilePlugin {
                   "opts": {
                     "seafowlClient": undefined,
                   },
@@ -188,7 +188,7 @@ describe("makeSeafowlHTTPContext", () => {
           "plugins": {
             "exporters": {},
             "importers": {
-              "csv": ImportCSVPlugin {
+              "csv": SeafowlImportFilePlugin {
                 "opts": {
                   "seafowlClient": undefined,
                 },

--- a/packages/core/seafowl.test.ts
+++ b/packages/core/seafowl.test.ts
@@ -44,6 +44,12 @@ describe("makeSeafowlHTTPContext", () => {
     expect(ctx.client).toBeTruthy();
     expect(ctx.db).toBeTruthy();
 
+    // NOTE: seafowlClient is expected to be undefined because we don't set it
+    // in the constructor (since it depends on the instantiated class). Instead
+    // we set it via a builder like withOptions (in other words, the instance
+    // created via `new DbSeafowl()` cannot control a seafowlClient, and must create
+    // a new instance from one of its builder methods to use a seafowlClient)
+    //    (this is not necessarily a desirable state of affairs)
     expect(ctx).toMatchInlineSnapshot(`
       {
         "client": SqlHTTPClient {
@@ -125,11 +131,9 @@ describe("makeSeafowlHTTPContext", () => {
               "exporters": {},
               "importers": {
                 "csv": ImportCSVPlugin {
-                  "graphqlEndpoint": "http://todo.test/should-not-be-required-property",
                   "opts": {
-                    "transformRequestHeaders": [Function],
+                    "seafowlClient": undefined,
                   },
-                  "transformRequestHeaders": [Function],
                 },
               },
             },
@@ -138,11 +142,9 @@ describe("makeSeafowlHTTPContext", () => {
             "exporters": {},
             "importers": {
               "csv": ImportCSVPlugin {
-                "graphqlEndpoint": "http://todo.test/should-not-be-required-property",
                 "opts": {
-                  "transformRequestHeaders": [Function],
+                  "seafowlClient": undefined,
                 },
-                "transformRequestHeaders": [Function],
               },
             },
           },

--- a/packages/core/seafowl.test.ts
+++ b/packages/core/seafowl.test.ts
@@ -2,10 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import { makeSeafowlHTTPContext } from "./seafowl";
 import { setupMswServerTestHooks } from "@madatdata/test-helpers/msw-server-hooks";
-import {
-  shouldSkipIntegrationTests,
-  shouldSkipSeafowlTests,
-} from "@madatdata/test-helpers/env-config";
+import { shouldSkipSeafowlTests } from "@madatdata/test-helpers/env-config";
 
 // @ts-expect-error https://stackoverflow.com/a/70711231
 const SEAFOWL_SECRET = import.meta.env.VITE_TEST_SEAFOWL_SECRET;
@@ -209,11 +206,4 @@ describe.skipIf(shouldSkipSeafowlTests())("can query local seafowl", () => {
       }
     `);
   });
-
-  it.skipIf(shouldSkipIntegrationTests())(
-    "can export data from splitrgaph, import it into seafowl",
-    async () => {
-      const { db } = createDataContext();
-    }
-  );
 });

--- a/packages/core/seafowl.test.ts
+++ b/packages/core/seafowl.test.ts
@@ -186,6 +186,7 @@ describe("makeSeafowlHTTPContext", () => {
             },
           },
           "plugins": PluginRegistry {
+            "hostContext": {},
             "plugins": {
               "exporters": {},
               "importers": {

--- a/packages/core/splitgraph-seafowl-sync.test.ts
+++ b/packages/core/splitgraph-seafowl-sync.test.ts
@@ -40,11 +40,11 @@ GROUP BY a ORDER BY a;`,
 
       const seafowlResp = await seafowl.db.importData(
         "csv",
-        { url: exportURL, format: "parquet" },
+        { url: exportURL!, format: "parquet" },
         seafowlDestOpts
       );
 
-      expect(seafowlResp.response.success).toBe(true);
+      expect(seafowlResp.response?.success).toBe(true);
 
       expect(seafowlResp).toMatchInlineSnapshot(`
       {

--- a/packages/core/splitgraph-seafowl-sync.test.ts
+++ b/packages/core/splitgraph-seafowl-sync.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldSkipIntegrationTests,
+  shouldSkipSeafowlTests,
+} from "@madatdata/test-helpers/env-config";
+import { randSuffix } from "@madatdata/test-helpers/rand-suffix";
+import { createRealDataContext as createRealSeafowlDataContext } from "./seafowl.test";
+import { createRealDataContext as createRealSplitgraphDataContext } from "./splitgraph.test";
+import type { SeafowlDestOptions } from "packages/db-seafowl/plugins/importers/base-seafowl-import-plugin";
+
+describe.skipIf(shouldSkipSeafowlTests() || shouldSkipIntegrationTests())(
+  "export splitgraph -> (parquet) -> URL -> seafowl, then query in seafowl",
+  () => {
+    it("can export from splitgraph", async () => {
+      const splitgraph = createRealSplitgraphDataContext();
+      const seafowl = createRealSeafowlDataContext();
+
+      const { response } = await splitgraph.db.exportData(
+        "exportQuery",
+        {
+          query: `SELECT a as int_val, string_agg(random()::text, '') as text_val
+FROM generate_series(1, 5) a, generate_series(1, 50) b
+GROUP BY a ORDER BY a;`,
+          vdbId: "ddn",
+        },
+        {
+          format: "parquet",
+          filename: "random-series",
+        }
+      );
+
+      const exportURL = response?.output.url;
+      expect(exportURL).toBeDefined();
+
+      const seafowlDestOpts: SeafowlDestOptions = {
+        tableName: `irrelevant_${randSuffix()}`,
+        // TODO: schemaName is currently a no-op (just not included in the interpolation of CREATE TABLE query)
+        schemaName: "public",
+      };
+
+      const seafowlResp = await seafowl.db.importData(
+        "csv",
+        { url: exportURL, format: "parquet" },
+        seafowlDestOpts
+      );
+
+      expect(seafowlResp.response.success).toBe(true);
+
+      expect(seafowlResp).toMatchInlineSnapshot(`
+      {
+        "error": null,
+        "info": {
+          "mountError": null,
+          "mountResponse": {
+            "readable": [Function],
+            "rows": [],
+            "success": true,
+          },
+        },
+        "response": {
+          "readable": [Function],
+          "rows": [],
+          "success": true,
+        },
+      }
+    `);
+
+      const queryResult = await seafowl.client.execute<{
+        int_val: number;
+        text_val: string;
+      }>(`SELECT * FROM ${seafowlDestOpts.tableName};`);
+
+      expect(queryResult.response?.success).toEqual(true);
+      expect(queryResult.response?.rows.length).toEqual(5);
+
+      // Check each row has an int_val and text_val column with appropriate types
+      // by asserting same length of original list and filtered list of matches
+      expect(
+        queryResult.response?.rows.filter(
+          (row) =>
+            Object.keys(row).length === 2 &&
+            Object.keys(row).includes("int_val") &&
+            Object.keys(row).includes("text_val") &&
+            typeof row["int_val"] === "number" &&
+            typeof row["text_val"] === "string"
+        ).length
+      ).toStrictEqual(queryResult.response?.rows.length);
+
+      expect({
+        ...queryResult.response,
+        rows: queryResult.response?.rows.map((row) => ({
+          ...row,
+          text_val: "unsnapshottable-random-text-val",
+        })),
+      }).toMatchInlineSnapshot(`
+      {
+        "readable": [Function],
+        "rows": [
+          {
+            "int_val": 1,
+            "text_val": "unsnapshottable-random-text-val",
+          },
+          {
+            "int_val": 2,
+            "text_val": "unsnapshottable-random-text-val",
+          },
+          {
+            "int_val": 3,
+            "text_val": "unsnapshottable-random-text-val",
+          },
+          {
+            "int_val": 4,
+            "text_val": "unsnapshottable-random-text-val",
+          },
+          {
+            "int_val": 5,
+            "text_val": "unsnapshottable-random-text-val",
+          },
+        ],
+        "success": true,
+      }
+    `);
+    }, 30_000);
+  }
+);

--- a/packages/core/splitgraph.test.ts
+++ b/packages/core/splitgraph.test.ts
@@ -3,17 +3,37 @@ import { describe, it, expect } from "vitest";
 import { makeSplitgraphHTTPContext } from "./splitgraph";
 import { setupMswServerTestHooks } from "@madatdata/test-helpers/msw-server-hooks";
 
+export const createDataContext = () => {
+  return makeSplitgraphHTTPContext({
+    authenticatedCredential: {
+      apiKey: "xxx",
+      apiSecret: "yyy",
+      anonymous: false,
+    },
+  });
+};
+
+export const createRealDataContext = () => {
+  const credential = {
+    // @ts-expect-error https://stackoverflow.com/a/70711231
+    apiKey: import.meta.env.VITE_TEST_DDN_API_KEY,
+    // @ts-expect-error https://stackoverflow.com/a/70711231
+    apiSecret: import.meta.env.VITE_TEST_DDN_API_SECRET,
+  };
+  return makeSplitgraphHTTPContext({
+    authenticatedCredential: {
+      apiKey: credential.apiKey,
+      apiSecret: credential.apiSecret,
+      anonymous: false,
+    },
+  });
+};
+
 describe("makeSplitgraphHTTPContext", () => {
   setupMswServerTestHooks();
 
   it("initializes as expected", async () => {
-    const ctx = makeSplitgraphHTTPContext({
-      authenticatedCredential: {
-        apiKey: "xxx",
-        apiSecret: "yyy",
-        anonymous: false,
-      },
-    });
+    const ctx = createDataContext();
 
     expect(ctx.client).toBeTruthy();
     expect(ctx.db).toBeTruthy();

--- a/packages/core/splitgraph.test.ts
+++ b/packages/core/splitgraph.test.ts
@@ -141,7 +141,7 @@ describe("makeSplitgraphHTTPContext", () => {
                 },
               },
               "importers": {
-                "csv": _ImportCSVPlugin {
+                "csv": _SplitgraphImportCSVPlugin {
                   "graphqlClient": SplitgraphGraphQLClient {
                     "graphqlClient": GraphQLClient {
                       "options": {
@@ -159,7 +159,7 @@ describe("makeSplitgraphHTTPContext", () => {
                   },
                   "transformRequestHeaders": [Function],
                 },
-                "mysql": _ImportCSVPlugin {
+                "mysql": _SplitgraphImportCSVPlugin {
                   "graphqlClient": SplitgraphGraphQLClient {
                     "graphqlClient": GraphQLClient {
                       "options": {
@@ -177,7 +177,7 @@ describe("makeSplitgraphHTTPContext", () => {
                   },
                   "transformRequestHeaders": [Function],
                 },
-                "postgres": _ImportCSVPlugin {
+                "postgres": _SplitgraphImportCSVPlugin {
                   "graphqlClient": SplitgraphGraphQLClient {
                     "graphqlClient": GraphQLClient {
                       "options": {
@@ -220,7 +220,7 @@ describe("makeSplitgraphHTTPContext", () => {
               },
             },
             "importers": {
-              "csv": _ImportCSVPlugin {
+              "csv": _SplitgraphImportCSVPlugin {
                 "graphqlClient": SplitgraphGraphQLClient {
                   "graphqlClient": GraphQLClient {
                     "options": {
@@ -238,7 +238,7 @@ describe("makeSplitgraphHTTPContext", () => {
                 },
                 "transformRequestHeaders": [Function],
               },
-              "mysql": _ImportCSVPlugin {
+              "mysql": _SplitgraphImportCSVPlugin {
                 "graphqlClient": SplitgraphGraphQLClient {
                   "graphqlClient": GraphQLClient {
                     "options": {
@@ -256,7 +256,7 @@ describe("makeSplitgraphHTTPContext", () => {
                 },
                 "transformRequestHeaders": [Function],
               },
-              "postgres": _ImportCSVPlugin {
+              "postgres": _SplitgraphImportCSVPlugin {
                 "graphqlClient": SplitgraphGraphQLClient {
                   "graphqlClient": GraphQLClient {
                     "options": {

--- a/packages/core/splitgraph.test.ts
+++ b/packages/core/splitgraph.test.ts
@@ -199,6 +199,7 @@ describe("makeSplitgraphHTTPContext", () => {
             },
           },
           "plugins": PluginRegistry {
+            "hostContext": {},
             "plugins": {
               "exporters": {
                 "exportQuery": _ExportQueryPlugin {

--- a/packages/core/splitgraph.test.ts
+++ b/packages/core/splitgraph.test.ts
@@ -198,81 +198,83 @@ describe("makeSplitgraphHTTPContext", () => {
               },
             },
           },
-          "plugins": {
-            "exporters": {
-              "exportQuery": _ExportQueryPlugin {
-                "graphqlClient": SplitgraphGraphQLClient {
-                  "graphqlClient": GraphQLClient {
-                    "options": {
-                      "headers": [Function],
+          "plugins": PluginRegistry {
+            "plugins": {
+              "exporters": {
+                "exportQuery": _ExportQueryPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
                     },
-                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
                   },
                   "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
                   "transformRequestHeaders": [Function],
                 },
-                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                "opts": {
-                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                  "transformRequestHeaders": [Function],
-                },
-                "transformRequestHeaders": [Function],
               },
-            },
-            "importers": {
-              "csv": _SplitgraphImportCSVPlugin {
-                "graphqlClient": SplitgraphGraphQLClient {
-                  "graphqlClient": GraphQLClient {
-                    "options": {
-                      "headers": [Function],
+              "importers": {
+                "csv": _SplitgraphImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
                     },
-                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
                   },
                   "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
                   "transformRequestHeaders": [Function],
                 },
-                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                "opts": {
-                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                  "transformRequestHeaders": [Function],
-                },
-                "transformRequestHeaders": [Function],
-              },
-              "mysql": _SplitgraphImportCSVPlugin {
-                "graphqlClient": SplitgraphGraphQLClient {
-                  "graphqlClient": GraphQLClient {
-                    "options": {
-                      "headers": [Function],
+                "mysql": _SplitgraphImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
                     },
-                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
                   },
                   "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
                   "transformRequestHeaders": [Function],
                 },
-                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                "opts": {
-                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                  "transformRequestHeaders": [Function],
-                },
-                "transformRequestHeaders": [Function],
-              },
-              "postgres": _SplitgraphImportCSVPlugin {
-                "graphqlClient": SplitgraphGraphQLClient {
-                  "graphqlClient": GraphQLClient {
-                    "options": {
-                      "headers": [Function],
+                "postgres": _SplitgraphImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
                     },
-                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
                   },
                   "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
                   "transformRequestHeaders": [Function],
                 },
-                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                "opts": {
-                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                  "transformRequestHeaders": [Function],
-                },
-                "transformRequestHeaders": [Function],
               },
             },
           },

--- a/packages/db-seafowl/db-seafowl.test.ts
+++ b/packages/db-seafowl/db-seafowl.test.ts
@@ -65,25 +65,6 @@ const createDb = () => {
 };
 
 describe.skipIf(shouldSkipSeafowlTests())("seafowl stub test", () => {
-  it("uploads with TableParamsSchema semicolon delimiter", async () => {
-    const db = createDb();
-
-    console.log("created db successfully");
-
-    expect(db).toBeTruthy();
-
-    const { response } = await db.importData(
-      "csv",
-      { data: Buffer.from(`name;candies\r\nBob;5\r\nAlice;10`) },
-      {
-        tableName: "irrelevant",
-        schemaName: "doesntmatter",
-      }
-    );
-
-    expect((response as any)?.success).toEqual(true);
-  });
-
   it("can fingerprint with sha256 by default", async () => {
     const db = createDb();
 

--- a/packages/db-seafowl/db-seafowl.test.ts
+++ b/packages/db-seafowl/db-seafowl.test.ts
@@ -32,6 +32,11 @@ const createDb = () => {
     database: {
       dbname: "seafowl", // arbitrary
     },
+    authenticatedCredential: {
+      // @ts-expect-error https://stackoverflow.com/a/70711231
+      token: import.meta.env.VITE_TEST_SEAFOWL_SECRET,
+      anonymous: false,
+    },
     host: {
       // temporary hacky mess
       dataHost: "127.0.0.1:8080",
@@ -91,9 +96,4 @@ describe.skipIf(shouldSkipSeafowlTests())("seafowl stub test", () => {
       }
     `);
   });
-
-  // it("can make a query to localhost", async () => {
-  //   const db = createDb();
-
-  // });
 });

--- a/packages/db-seafowl/db-seafowl.test.ts
+++ b/packages/db-seafowl/db-seafowl.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { makeDb } from "./db-seafowl";
 import { ImportCSVPlugin } from "./plugins/importers/import-csv-seafowl-plugin";
 
@@ -23,12 +23,12 @@ describe("importData", () => {
 });
 
 const createDb = () => {
-  const transformRequestHeaders = vi.fn((headers) => ({
-    ...headers,
-    foobar: "fizzbuzz",
-  }));
+  // const transformRequestHeaders = vi.fn((headers) => ({
+  //   ...headers,
+  //   foobar: "fizzbuzz",
+  // }));
 
-  return makeDb({
+  const db = makeDb({
     database: {
       dbname: "seafowl", // arbitrary
     },
@@ -55,13 +55,13 @@ const createDb = () => {
     },
     plugins: {
       importers: {
-        csv: new ImportCSVPlugin({
-          transformRequestHeaders,
-        }),
+        csv: new ImportCSVPlugin({}),
       },
       exporters: {},
     },
   });
+
+  return db;
 };
 
 describe.skipIf(shouldSkipSeafowlTests())("seafowl stub test", () => {

--- a/packages/db-seafowl/db-seafowl.test.ts
+++ b/packages/db-seafowl/db-seafowl.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { makeDb } from "./db-seafowl";
-import { ImportCSVPlugin } from "./plugins/importers/import-csv-seafowl-plugin";
+import { SeafowlImportFilePlugin } from "./plugins/importers/seafowl-import-file-plugin";
 
 import { shouldSkipSeafowlTests } from "@madatdata/test-helpers/env-config";
 
@@ -55,7 +55,7 @@ const createDb = () => {
     },
     plugins: {
       importers: {
-        csv: new ImportCSVPlugin({}),
+        csv: new SeafowlImportFilePlugin({}),
       },
       exporters: {},
     },

--- a/packages/db-seafowl/db-seafowl.ts
+++ b/packages/db-seafowl/db-seafowl.ts
@@ -6,7 +6,7 @@ import type {
 } from "./plugins/importers";
 
 // TODO: This sould be injected in the constructor as the actual plugin map
-import { ImportCSVPlugin } from "./plugins/importers/import-csv-seafowl-plugin";
+import { SeafowlImportFilePlugin } from "./plugins/importers/seafowl-import-file-plugin";
 
 // TODO: It's not ideal for db-splitgraph to depend on base-client
 import {
@@ -29,7 +29,7 @@ interface DbSeafowlOptions
 // this is because the type is self referential (config object needs class instantiated)
 const makeDefaultPluginMap = (opts: { seafowlClient?: Client }) => ({
   importers: {
-    csv: new ImportCSVPlugin({ seafowlClient: opts.seafowlClient }),
+    csv: new SeafowlImportFilePlugin({ seafowlClient: opts.seafowlClient }),
   },
   exporters: {},
 });

--- a/packages/db-seafowl/db-seafowl.ts
+++ b/packages/db-seafowl/db-seafowl.ts
@@ -1,4 +1,9 @@
-import { BaseDb, OptionalPluginMap, type DbOptions } from "@madatdata/base-db";
+import {
+  BaseDb,
+  OptionalPluginMap,
+  type DbOptions,
+  type WithPlugins,
+} from "@madatdata/base-db";
 import type {
   SeafowlPluginMap,
   SeafowlExportPluginMap,
@@ -52,7 +57,10 @@ const guessMethodForQuery = (query: string) => {
     : "GET";
 };
 
-export class DbSeafowl extends BaseDb<OptionalPluginMap<SeafowlPluginMap>> {
+export class DbSeafowl
+  extends BaseDb<OptionalPluginMap<SeafowlPluginMap>>
+  implements WithPlugins<SeafowlPluginMap>
+{
   constructor(
     opts: Omit<DbSeafowlOptions, "plugins"> &
       Pick<Partial<DbSeafowlOptions>, "plugins">

--- a/packages/db-seafowl/db-seafowl.ts
+++ b/packages/db-seafowl/db-seafowl.ts
@@ -135,7 +135,7 @@ export class DbSeafowl
             ? host.baseUrls.sql + "/" + fingerprint
             : host.baseUrls.sql;
         },
-      } as HTTPStrategies,
+      },
     };
   }
 
@@ -149,7 +149,7 @@ export class DbSeafowl
     // FIXME: do we need to depend on all of client-http just for `strategies` type?
     // FIXME: this pattern would probably work better as a user-provided Class
     // nb: careful to keep parity with (intentionally) same code in db-splitgraph.ts
-    return super.makeClient<HTTPClientOptions>(
+    return super.makeClient<HTTPClientOptions, HTTPStrategies>(
       makeClientForProtocol ?? makeHTTPClient,
       {
         ...clientOptions,

--- a/packages/db-seafowl/db-seafowl.ts
+++ b/packages/db-seafowl/db-seafowl.ts
@@ -2,7 +2,7 @@ import {
   BaseDb,
   OptionalPluginMap,
   type DbOptions,
-  type WithPlugins,
+  type WithPluginRegistry,
 } from "@madatdata/base-db";
 import type {
   SeafowlPluginMap,
@@ -57,9 +57,16 @@ const guessMethodForQuery = (query: string) => {
     : "GET";
 };
 
+interface DbSeafowlPluginHostContext {
+  seafowlClient: Client;
+}
+
 export class DbSeafowl
-  extends BaseDb<OptionalPluginMap<SeafowlPluginMap>>
-  implements WithPlugins<SeafowlPluginMap>
+  extends BaseDb<
+    OptionalPluginMap<SeafowlPluginMap>,
+    DbSeafowlPluginHostContext
+  >
+  implements WithPluginRegistry<SeafowlPluginMap, DbSeafowlPluginHostContext>
 {
   constructor(
     opts: Omit<DbSeafowlOptions, "plugins"> &

--- a/packages/db-seafowl/plugins/importers/index.ts
+++ b/packages/db-seafowl/plugins/importers/index.ts
@@ -1,10 +1,14 @@
 import type { ImportPlugin } from "@madatdata/base-db";
+import type { SeafowlImportFilePlugin } from "./seafowl-import-file-plugin";
 
 type DEFAULT_IMPORT_PLUGINS = "csv";
 
 type DefaultPluginMap = {
+  // NOTE: hacky, only works for one plugin really
   importers: {
-    [k in DEFAULT_IMPORT_PLUGINS]: ImportPlugin;
+    [k in DEFAULT_IMPORT_PLUGINS]: k extends "csv" | "parquet"
+      ? SeafowlImportFilePlugin
+      : ImportPlugin;
   };
   exporters: {};
 };

--- a/packages/db-seafowl/plugins/importers/index.ts
+++ b/packages/db-seafowl/plugins/importers/index.ts
@@ -5,11 +5,12 @@ type DEFAULT_IMPORT_PLUGINS = "csv";
 
 type DefaultPluginMap = {
   // NOTE: hacky, only works for one plugin really
-  importers: {
-    [k in DEFAULT_IMPORT_PLUGINS]: k extends "csv" | "parquet"
-      ? SeafowlImportFilePlugin
-      : ImportPlugin;
-  };
+  importers:
+    | {
+        [k in DEFAULT_IMPORT_PLUGINS]: k extends "csv" | "parquet"
+          ? SeafowlImportFilePlugin
+          : ImportPlugin;
+      };
   exporters: {};
 };
 

--- a/packages/db-splitgraph/db-splitgraph.test.ts
+++ b/packages/db-splitgraph/db-splitgraph.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { randSuffix } from "@madatdata/test-helpers/rand-suffix";
 import { makeDb } from "./db-splitgraph";
 import { ImportCSVPlugin } from "./plugins/importers/import-csv-plugin";
 import { ExportQueryPlugin } from "./plugins/exporters/export-query-plugin";
@@ -535,7 +536,7 @@ describe("importData for ImportCSVPlugin", () => {
 
 // TODO: Make a mocked version of this test
 describe.skipIf(shouldSkipIntegrationTests())("real export query", () => {
-  it("exports a basic postgres query to CSV", async () => {
+  it("exports a basic postgres query to parquet", async () => {
     const db = createRealDb();
 
     const { response, error, info } = await db.exportData(
@@ -547,7 +548,7 @@ GROUP BY a ORDER BY a;`,
         vdbId: "ddn",
       },
       {
-        format: "csv",
+        format: "parquet",
         filename: "random-series",
       }
     );
@@ -556,6 +557,8 @@ GROUP BY a ORDER BY a;`,
     expect(info).toBeDefined();
 
     expect(response?.output.url).toBeDefined();
+
+    console.log("output URL:", response?.output.url);
 
     expect(() => new URL(response?.output.url!)).not.toThrow();
 
@@ -570,8 +573,8 @@ GROUP BY a ORDER BY a;`,
         : { url: "error-in-url" },
     }).toMatchInlineSnapshot(`
       {
-        "exportFormat": "csv",
-        "filename": "random-series.csv",
+        "exportFormat": "parquet",
+        "filename": "random-series.parquet",
         "finished": "finished-ok",
         "output": {
           "url": "url-ok",
@@ -596,7 +599,7 @@ describe.skipIf(shouldSkipIntegrationTests())("real DDN", () => {
       "csv",
       { data: Buffer.from(`name;candies\r\nBob;5\r\nAlice;10`) },
       {
-        tableName: "irrelevant",
+        tableName: `irrelevant-${randSuffix()}`,
         namespace,
         repository: "dunno",
         tableParams: {

--- a/packages/db-splitgraph/db-splitgraph.test.ts
+++ b/packages/db-splitgraph/db-splitgraph.test.ts
@@ -33,6 +33,8 @@ const createDb = () => {
       apiSecret: "yyy",
       anonymous: false,
     },
+    graphqlEndpoint: defaultHost.baseUrls.gql,
+    transformRequestHeaders,
     plugins: {
       importers: {
         csv: new ImportCSVPlugin({

--- a/packages/db-splitgraph/db-splitgraph.test.ts
+++ b/packages/db-splitgraph/db-splitgraph.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { randSuffix } from "@madatdata/test-helpers/rand-suffix";
 import { makeDb } from "./db-splitgraph";
-import { ImportCSVPlugin } from "./plugins/importers/import-csv-plugin";
+import { SplitgraphImportCSVPlugin } from "./plugins/importers/splitgraph-import-csv-plugin";
 import { ExportQueryPlugin } from "./plugins/exporters/export-query-plugin";
 
 import { shouldSkipIntegrationTests } from "@madatdata/test-helpers/env-config";
@@ -38,7 +38,7 @@ const createDb = () => {
     transformRequestHeaders,
     plugins: {
       importers: {
-        csv: new ImportCSVPlugin({
+        csv: new SplitgraphImportCSVPlugin({
           graphqlEndpoint: defaultHost.baseUrls.gql,
           transformRequestHeaders,
         }),
@@ -72,7 +72,7 @@ const createRealDb = () => {
     },
     plugins: {
       importers: {
-        csv: new ImportCSVPlugin({
+        csv: new SplitgraphImportCSVPlugin({
           graphqlEndpoint: defaultHost.baseUrls.gql,
         }),
       },
@@ -89,7 +89,7 @@ const createRealDb = () => {
 // const _makeAnonymousDb = () => {
 //   return makeDb({
 //     plugins: {
-//       csv: new ImportCSVPlugin({
+//       csv: new SplitgraphImportCSVPlugin({
 //         graphqlEndpoint: defaultHost.baseUrls.gql,
 //       }),
 //     },
@@ -97,7 +97,7 @@ const createRealDb = () => {
 // };
 
 // FIXME: most of this block is graphql client implementation details
-describe("importData for ImportCSVPlugin", () => {
+describe("importData for SplitgraphImportCSVPlugin", () => {
   setupMswServerTestHooks();
   setupMemo();
 
@@ -300,7 +300,7 @@ describe("importData for ImportCSVPlugin", () => {
               started: string;
               finished: string;
               isManual: boolean;
-              // FIXME: it's really TaskStatus (needs export from import-csv-plugin)
+              // FIXME: it's really TaskStatus (needs export from splitgraph-import-csv-plugin)
               status: string;
             }[];
           };
@@ -557,8 +557,6 @@ GROUP BY a ORDER BY a;`,
     expect(info).toBeDefined();
 
     expect(response?.output.url).toBeDefined();
-
-    console.log("output URL:", response?.output.url);
 
     expect(() => new URL(response?.output.url!)).not.toThrow();
 

--- a/packages/db-splitgraph/db-splitgraph.ts
+++ b/packages/db-splitgraph/db-splitgraph.ts
@@ -6,7 +6,7 @@ import type {
 } from "./plugins/importers";
 
 // TODO: These could be injected in the constructor as the actual plugin map
-import { ImportCSVPlugin } from "./plugins/importers/import-csv-plugin";
+import { SplitgraphImportCSVPlugin } from "./plugins/importers/splitgraph-import-csv-plugin";
 import { ExportQueryPlugin } from "./plugins/exporters/export-query-plugin";
 
 // TODO: It's not ideal for db-splitgraph to depend on base-client
@@ -49,10 +49,10 @@ const makeDefaultPluginMap = (
 
   return {
     importers: {
-      csv: new ImportCSVPlugin({ ...graphqlOptions }),
+      csv: new SplitgraphImportCSVPlugin({ ...graphqlOptions }),
       // TODO: not real obviously
-      mysql: new ImportCSVPlugin({ ...graphqlOptions }),
-      postgres: new ImportCSVPlugin({ ...graphqlOptions }),
+      mysql: new SplitgraphImportCSVPlugin({ ...graphqlOptions }),
+      postgres: new SplitgraphImportCSVPlugin({ ...graphqlOptions }),
     },
     exporters: {
       exportQuery: new ExportQueryPlugin({ ...graphqlOptions }),

--- a/packages/db-splitgraph/plugins/exporters/export-query-plugin.ts
+++ b/packages/db-splitgraph/plugins/exporters/export-query-plugin.ts
@@ -182,7 +182,7 @@ export class ExportQueryPlugin
     );
   }
 
-  // TODO: DRY (with at least import-csv-plugin)
+  // TODO: DRY (with at least splitgraph-import-csv-plugin)
   @Retryable({
     ...retryOptions,
     doRetry: ({ type }) => type === "retry",

--- a/packages/db-splitgraph/plugins/importers/index.ts
+++ b/packages/db-splitgraph/plugins/importers/index.ts
@@ -1,11 +1,11 @@
-import type { ImportCSVPlugin } from "./import-csv-plugin";
+import type { SplitgraphImportCSVPlugin } from "./splitgraph-import-csv-plugin";
 import type { /*ExportPlugin,*/ ImportPlugin } from "@madatdata/base-db";
 import type { ExportQueryPlugin } from "../exporters/export-query-plugin";
 
 // NOTE: In theory this will be auto-generated
 type DEFAULT_IMPORT_PLUGINS = "mysql" | "postgres";
 type SPECIAL_IMPORT_PLUGINS = {
-  csv: ImportCSVPlugin;
+  csv: SplitgraphImportCSVPlugin;
 };
 export type SplitgraphPluginMap = {
   importers: {

--- a/packages/db-splitgraph/plugins/importers/splitgraph-import-csv-plugin.ts
+++ b/packages/db-splitgraph/plugins/importers/splitgraph-import-csv-plugin.ts
@@ -16,7 +16,7 @@ import type {
   RepositoryIngestionJobStatusQueryVariables,
   StartExternalRepositoryLoadMutation,
   StartExternalRepositoryLoadMutationVariables,
-} from "./import-csv-plugin.generated";
+} from "./splitgraph-import-csv-plugin.generated";
 
 interface ImportCSVDestOptions extends SplitgraphDestOptions {
   params?: CsvParamsSchema;
@@ -74,8 +74,8 @@ const retryOptions = {
   exponentialOption: { maxInterval: MAX_BACKOFF_INTERVAL, multiplier: 2 },
 };
 
-export class ImportCSVPlugin
-  implements ImportPlugin, WithOptionsInterface<ImportCSVPlugin>
+export class SplitgraphImportCSVPlugin
+  implements ImportPlugin, WithOptionsInterface<SplitgraphImportCSVPlugin>
 {
   public readonly opts: ImportCSVPluginOptions;
   public readonly graphqlEndpoint: ImportCSVPluginOptions["graphqlEndpoint"];
@@ -96,7 +96,7 @@ export class ImportCSVPlugin
 
   // TODO: improve it (e.g. allow either mutation or copy), and/or generalize it
   withOptions(injectOpts: DbInjectedOptions) {
-    return new ImportCSVPlugin({
+    return new SplitgraphImportCSVPlugin({
       ...this.opts,
       ...injectOpts,
       // TODO: replace transformer with some kind of chainable "link" plugin

--- a/packages/react/hooks.test.tsx
+++ b/packages/react/hooks.test.tsx
@@ -277,81 +277,83 @@ describe("makeDefaultAnonymousContext", () => {
               },
             },
           },
-          "plugins": {
-            "exporters": {
-              "exportQuery": _ExportQueryPlugin {
-                "graphqlClient": SplitgraphGraphQLClient {
-                  "graphqlClient": GraphQLClient {
-                    "options": {
-                      "headers": [Function],
+          "plugins": PluginRegistry {
+            "plugins": {
+              "exporters": {
+                "exportQuery": _ExportQueryPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
                     },
-                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
                   },
                   "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
                   "transformRequestHeaders": [Function],
                 },
-                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                "opts": {
-                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                  "transformRequestHeaders": [Function],
-                },
-                "transformRequestHeaders": [Function],
               },
-            },
-            "importers": {
-              "csv": _SplitgraphImportCSVPlugin {
-                "graphqlClient": SplitgraphGraphQLClient {
-                  "graphqlClient": GraphQLClient {
-                    "options": {
-                      "headers": [Function],
+              "importers": {
+                "csv": _SplitgraphImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
                     },
-                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
                   },
                   "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
                   "transformRequestHeaders": [Function],
                 },
-                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                "opts": {
-                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                  "transformRequestHeaders": [Function],
-                },
-                "transformRequestHeaders": [Function],
-              },
-              "mysql": _SplitgraphImportCSVPlugin {
-                "graphqlClient": SplitgraphGraphQLClient {
-                  "graphqlClient": GraphQLClient {
-                    "options": {
-                      "headers": [Function],
+                "mysql": _SplitgraphImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
                     },
-                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
                   },
                   "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
                   "transformRequestHeaders": [Function],
                 },
-                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                "opts": {
-                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                  "transformRequestHeaders": [Function],
-                },
-                "transformRequestHeaders": [Function],
-              },
-              "postgres": _SplitgraphImportCSVPlugin {
-                "graphqlClient": SplitgraphGraphQLClient {
-                  "graphqlClient": GraphQLClient {
-                    "options": {
-                      "headers": [Function],
+                "postgres": _SplitgraphImportCSVPlugin {
+                  "graphqlClient": SplitgraphGraphQLClient {
+                    "graphqlClient": GraphQLClient {
+                      "options": {
+                        "headers": [Function],
+                      },
+                      "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
                     },
-                    "url": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
                   },
                   "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                  "opts": {
+                    "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+                    "transformRequestHeaders": [Function],
+                  },
                   "transformRequestHeaders": [Function],
                 },
-                "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                "opts": {
-                  "graphqlEndpoint": "https://api.splitgraph.com/gql/cloud/unified/graphql",
-                  "transformRequestHeaders": [Function],
-                },
-                "transformRequestHeaders": [Function],
               },
             },
           },

--- a/packages/react/hooks.test.tsx
+++ b/packages/react/hooks.test.tsx
@@ -278,6 +278,7 @@ describe("makeDefaultAnonymousContext", () => {
             },
           },
           "plugins": PluginRegistry {
+            "hostContext": {},
             "plugins": {
               "exporters": {
                 "exportQuery": _ExportQueryPlugin {

--- a/packages/react/hooks.test.tsx
+++ b/packages/react/hooks.test.tsx
@@ -220,7 +220,7 @@ describe("makeDefaultAnonymousContext", () => {
                 },
               },
               "importers": {
-                "csv": _ImportCSVPlugin {
+                "csv": _SplitgraphImportCSVPlugin {
                   "graphqlClient": SplitgraphGraphQLClient {
                     "graphqlClient": GraphQLClient {
                       "options": {
@@ -238,7 +238,7 @@ describe("makeDefaultAnonymousContext", () => {
                   },
                   "transformRequestHeaders": [Function],
                 },
-                "mysql": _ImportCSVPlugin {
+                "mysql": _SplitgraphImportCSVPlugin {
                   "graphqlClient": SplitgraphGraphQLClient {
                     "graphqlClient": GraphQLClient {
                       "options": {
@@ -256,7 +256,7 @@ describe("makeDefaultAnonymousContext", () => {
                   },
                   "transformRequestHeaders": [Function],
                 },
-                "postgres": _ImportCSVPlugin {
+                "postgres": _SplitgraphImportCSVPlugin {
                   "graphqlClient": SplitgraphGraphQLClient {
                     "graphqlClient": GraphQLClient {
                       "options": {
@@ -299,7 +299,7 @@ describe("makeDefaultAnonymousContext", () => {
               },
             },
             "importers": {
-              "csv": _ImportCSVPlugin {
+              "csv": _SplitgraphImportCSVPlugin {
                 "graphqlClient": SplitgraphGraphQLClient {
                   "graphqlClient": GraphQLClient {
                     "options": {
@@ -317,7 +317,7 @@ describe("makeDefaultAnonymousContext", () => {
                 },
                 "transformRequestHeaders": [Function],
               },
-              "mysql": _ImportCSVPlugin {
+              "mysql": _SplitgraphImportCSVPlugin {
                 "graphqlClient": SplitgraphGraphQLClient {
                   "graphqlClient": GraphQLClient {
                     "options": {
@@ -335,7 +335,7 @@ describe("makeDefaultAnonymousContext", () => {
                 },
                 "transformRequestHeaders": [Function],
               },
-              "postgres": _ImportCSVPlugin {
+              "postgres": _SplitgraphImportCSVPlugin {
                 "graphqlClient": SplitgraphGraphQLClient {
                   "graphqlClient": GraphQLClient {
                     "options": {

--- a/packages/react/hooks.tsx
+++ b/packages/react/hooks.tsx
@@ -141,7 +141,5 @@ export const HelloButton = () => {
     [setState, state]
   );
 
-  console.log("v1");
-
   return <button onClick={toggle}>{state}</button>;
 };

--- a/packages/test-helpers/env-config.ts
+++ b/packages/test-helpers/env-config.ts
@@ -1,4 +1,4 @@
-const environmentHasCredential = () => {
+const environmentHasSplitgraphCredential = () => {
   return (
     // @ts-expect-error https://stackoverflow.com/a/70711231
     !!import.meta.env.VITE_TEST_DDN_API_KEY &&
@@ -7,9 +7,19 @@ const environmentHasCredential = () => {
   );
 };
 
+// Seafowl tests will only run if environment has this credential
+const environmentHasSeafowlCredential = () => {
+  return (
+    // @ts-expect-error https://stackoverflow.com/a/70711231
+    !!import.meta.env.VITE_TEST_SEAFOWL_SECRET
+  );
+};
+
+// TODO: Once Seafowl integration tests can run in CI, add condition
+// here that integration tests also require seafowl secret to be defined
 const shouldIncludeIntegrationTests = () => {
   return (
-    environmentHasCredential() &&
+    environmentHasSplitgraphCredential() &&
     // @ts-expect-error https://stackoverflow.com/a/70711231
     !!import.meta.env.VITE_TEST_INTEGRATION
   );
@@ -63,7 +73,5 @@ export const shouldSkipIntegrationTests = () => {
 };
 
 export const shouldSkipSeafowlTests = () => {
-  // TEMP: true for commit in CI (uncomment for local dev)
-  // (because there is no seafowl setup in CI yet)
-  return true;
+  return !environmentHasSeafowlCredential();
 };

--- a/packages/test-helpers/rand-suffix.ts
+++ b/packages/test-helpers/rand-suffix.ts
@@ -1,0 +1,5 @@
+// https://stackoverflow.com/a/24810220/3793499
+export const randSuffix = () =>
+  new Array(5).join().replace(/(.|$)/g, function () {
+    return ((Math.random() * 36) | 0).toString(36);
+  });


### PR DESCRIPTION
This PR contains the bare minimum implementation of the `SeafowlImportFile` plugin. Example usage (from `splitgraph-seafowl-sync.test.ts`), exporting a Splitgraph query to a Parquet file at a URL and then importing that Parquet file into Seafowl:

```ts
// EXPORT the data from Splitgraph to a URL of a parquet file
const { response } = await splitgraph.db.exportData(
  "exportQuery",
  {
    query: `SELECT a as int_val, string_agg(random()::text, '') as text_val
FROM generate_series(1, 5) a, generate_series(1, 50) b
GROUP BY a ORDER BY a;`,
    vdbId: "ddn",
  },
  {
    format: "parquet",
    filename: "random-series",
  }
);

const exportURL = response?.output.url;

// IMPORT the data to Seafowl (create external table, then create table with select * from it)
await seafowl.db.importData(
  "csv", // NOTE: this is a bug, it should be "file" but I missed this during refactor
  { url: exportURL!, format: "parquet" },
  { tableName: "random-series", schemaName: "public" }
);

// QUERY the data inside of Seafowl
const queryResult = await seafowl.client.execute<{
  int_val: number;
  text_val: string;
}>(`SELECT * FROM random-series;`);
```

<details><summary>Boilerplate initialization code</summary>

This needs to be simplified for Seafowl, the only relevant key is really the host of the DB.

```ts
import { makeSeafowlHTTPContext } from "@madatdata/core/seafowl";
import { makeSplitgraphHTTPContext } from "@madatdata/core/splitgraph";

const splitgraph = makeSplitgraphHTTPContext({
  authenticatedCredential: {
    apiKey: process.env.SPLITGRAPH_API_KEY,
    apiSecret: process.env.SPLITGRAPH_API_SECRET,
    anonymous: false,
  },
});

const seafowl = makeSeafowlHTTPContext({
  database: {
    dbname: "seafowl", // arbitrary
  },
  authenticatedCredential: {
    // @ts-expect-error https://stackoverflow.com/a/70711231
    token: process.env.VITE_TEST_SEAFOWL_SECRET,
    anonymous: false,
  },
  host: {
    // temporary hacky mess
    dataHost: "127.0.0.1:8080",
    apexDomain: "bogus",
    apiHost: "bogus",
    baseUrls: {
      gql: "bogus",
      sql: "http://127.0.0.1:8080/q",
      auth: "bogus",
    },
    postgres: {
      host: "127.0.0.1",
      port: 6432,
      ssl: false,
    },
  },
});
```


</details>

Also in this PR is some WIP refactoring of the plugin system. The types are messy because they're just porting status quo to be in a fancier PluginRegistry container; actual simplification is coming next.