### PR TITLE
Update react-vite-basic-hooks example

### DIFF
--- a/examples/react-vite-basic-hooks/README.md
+++ b/examples/react-vite-basic-hooks/README.md
@@ -28,7 +28,7 @@ Splitgraph repository (see [`./pages/index.tsx`](./pages/index.tsx)):
 
 ## Try Now
 
-- [🚀 Click to Deploy Immediately to **StackBlitz**](https://stackblitz.com/github/splitgraph/madatdata/tree/main/examples/react-vite-basic-hooks?file=README.md)
+- [🚀 Click to Deploy Immediately to **StackBlitz**](https://stackblitz.com/github/splitgraph/madatdata/tree/main/examples/react-vite-basic-hooks?file=src/App.tsx)
   (no signup required!)
 
 - [🚀 Click to Deploy to **Vercel**](https://vercel.com/new/git/external?repository-url=https://github.com/splitgraph/madatdata/tree/main/examples/react-vite-basic-hooks&project-name=madatdata-basic-hooks&repository-name=madatdata-vite-basic-hooks)

--- a/examples/react-vite-basic-hooks/package.json
+++ b/examples/react-vite-basic-hooks/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@madatdata/react": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -2119,6 +2119,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-vite-basic-hooks@workspace:react-vite-basic-hooks"
   dependencies:
+    "@madatdata/react": latest
     "@types/react": ^18.0.28
     "@types/react-dom": ^18.0.11
     "@vitejs/plugin-react": ^3.1.0


### PR DESCRIPTION
Add missing madatdata dependency, and make Stackblitz link open App.tsx by default (that's where the interesting code is).