### PR TITLE
Add CodeSandbox links to examples, and use images as links for the de…

### DIFF
--- a/examples/react-nextjs-basic-hooks/README.md
+++ b/examples/react-nextjs-basic-hooks/README.md
@@ -9,8 +9,16 @@ Splitgraph repository (see [`./pages/index.tsx`](./pages/index.tsx)):
 
 ## Try Now
 
-- [🚀 Click to Deploy Immediately to **StackBlitz**](https://stackblitz.com/github/splitgraph/madatdata/tree/main/examples/react-nextjs-basic-hooks?file=pages/index.tsx)
-  (no signup required!)
+### Preview Immediately
 
-- [🚀 Click to Deploy to **Vercel**](https://vercel.com/new/git/external?repository-url=https://github.com/splitgraph/madatdata/tree/main/examples/react-nextjs-basic-hooks&project-name=madatdata-basic-hooks&repository-name=madatdata-nextjs-basic-hooks)
-  (signup and new repo required)
+_No signup required, just click the button!_
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/splitgraph/madatdata/tree/main/examples/react-nextjs-basic-hooks?file=pages/index.tsx)
+
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/splitgraph/madatdata/main/examples/react-nextjs-basic-hooks?file=pages/index.tsx&hardReloadOnChange=true&startScript=dev&node=16&port=3000)
+
+### Or, deploy to Vercel (signup required)
+
+_Signup, fork the repo, and import it_
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/splitgraph/madatdata/tree/main/examples/react-nextjs-basic-hooks&project-name=madatdata-basic-hooks&repository-name=madatdata-nextjs-basic-hooks)

--- a/examples/react-nextjs-seafowl/README.md
+++ b/examples/react-nextjs-seafowl/README.md
@@ -19,11 +19,19 @@ with Cloudflare in front of it at `demo.seafowl.cloud` providing a caching layer
 
 ## Try Now
 
-- [🚀 Click to Deploy Immediately to **StackBlitz**](https://stackblitz.com/github/splitgraph/madatdata/tree/main/examples/react-nextjs-seafowl?file=README.md)
-  (no signup required!)
+### Preview Immediately
 
-- [🚀 Click to Deploy to **Vercel**](https://vercel.com/new/git/external?repository-url=https://github.com/splitgraph/madatdata/tree/main/examples/react-nextjs-seafowl&project-name=madatdata-seafowl&repository-name=madatdata-nextjs-seafowl)
-  (signup and new repo required)
+_No signup required, just click the button!_
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/splitgraph/madatdata/tree/main/examples/react-nextjs-seafowl?file=sql-queries.ts)
+
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/splitgraph/madatdata/main/examples/react-nextjs-seafowl?file=sql-queries.ts&hardReloadOnChange=true&startScript=dev&node=16&port=3000)
+
+### Or, deploy to Vercel (signup required)
+
+_Signup, fork the repo, and import it_
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/splitgraph/madatdata/tree/main/examples/react-nextjs-seafowl&project-name=madatdata-seafowl&repository-name=madatdata-nextjs-seafowl)
 
 ## Queries
 

--- a/examples/react-vite-basic-hooks/README.md
+++ b/examples/react-vite-basic-hooks/README.md
@@ -28,8 +28,10 @@ Splitgraph repository (see [`./src/App.tsx`](./src/App.tsx)):
 
 ## Try Now
 
-- [🚀 Click to Deploy Immediately to **StackBlitz**](https://stackblitz.com/github/splitgraph/madatdata/tree/main/examples/react-vite-basic-hooks?file=src/App.tsx)
-  (no signup required!)
+### Preview Immediately
 
-- [🚀 Click to Deploy to **Vercel**](https://vercel.com/new/git/external?repository-url=https://github.com/splitgraph/madatdata/tree/main/examples/react-vite-basic-hooks&project-name=madatdata-basic-hooks&repository-name=madatdata-vite-basic-hooks)
-  (signup and new repo required)
+_No signup required, just click the button!_
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/splitgraph/madatdata/tree/main/examples/react-vite-basic-hooks?file=src/App.tsx)
+
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/splitgraph/madatdata/main/examples/react-vite-basic-hooks?file=src/App.tsx)


### PR DESCRIPTION
The CodeSandbox links are kinda janky, because they open a preview for multiple open ports they detect (hot reload servers? idk). I tried to add the port to the URL, and I think it works, but it's cached and shared globally somehow, so maybe eventually will be fine.