### PR TITLE
Draft: [do not merge] Canary

### DIFF
--- a/packages/base-client/package.json
+++ b/packages/base-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madatdata/base-client",
-  "version": "0.0.9",
+  "version": "0.0.10-0",
   "packageManager": "yarn@3.2.0",
   "main": "index.ts",
   "types": "./build/es2020/index.d.ts",
@@ -41,5 +41,6 @@
   "scripts": {
     "version": "yarn version",
     "publish": "yarn npm publish"
-  }
+  },
+  "stableVersion": "0.0.9"
 }

--- a/packages/base-db/package.json
+++ b/packages/base-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madatdata/base-db",
-  "version": "0.0.9",
+  "version": "0.0.10-0",
   "packageManager": "yarn@3.2.0",
   "main": "index.ts",
   "types": "./build/es2020/index.d.ts",
@@ -44,5 +44,6 @@
   "scripts": {
     "version": "yarn version",
     "publish": "yarn npm publish"
-  }
+  },
+  "stableVersion": "0.0.9"
 }

--- a/packages/client-http/package.json
+++ b/packages/client-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madatdata/client-http",
-  "version": "0.0.9",
+  "version": "0.0.10-0",
   "packageManager": "yarn@3.2.0",
   "main": "index.ts",
   "types": "./build/es2020/index.d.ts",
@@ -48,5 +48,6 @@
   "scripts": {
     "version": "yarn version",
     "publish": "yarn npm publish"
-  }
+  },
+  "stableVersion": "0.0.9"
 }

--- a/packages/client-postgres/package.json
+++ b/packages/client-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madatdata/client-postgres",
-  "version": "0.0.9",
+  "version": "0.0.10-0",
   "packageManager": "yarn@3.2.0",
   "main": "index.ts",
   "types": "./build/es2020/index.d.ts",
@@ -43,5 +43,6 @@
   "scripts": {
     "version": "yarn version",
     "publish": "yarn npm publish"
-  }
+  },
+  "stableVersion": "0.0.9"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madatdata/core",
-  "version": "0.0.9",
+  "version": "0.0.10-0",
   "packageManager": "yarn@3.2.0",
   "main": "index.ts",
   "types": "./build/es2020/index.d.ts",
@@ -45,5 +45,6 @@
   "scripts": {
     "version": "yarn version",
     "publish": "yarn npm publish"
-  }
+  },
+  "stableVersion": "0.0.9"
 }

--- a/packages/db-seafowl/package.json
+++ b/packages/db-seafowl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madatdata/db-seafowl",
-  "version": "0.0.9",
+  "version": "0.0.10-0",
   "packageManager": "yarn@3.2.0",
   "main": "index.ts",
   "types": "./build/es2020/index.d.ts",
@@ -43,5 +43,6 @@
   "scripts": {
     "version": "yarn version",
     "publish": "yarn npm publish"
-  }
+  },
+  "stableVersion": "0.0.9"
 }

--- a/packages/db-splitgraph/package.json
+++ b/packages/db-splitgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madatdata/db-splitgraph",
-  "version": "0.0.9",
+  "version": "0.0.10-0",
   "packageManager": "yarn@3.2.0",
   "main": "index.ts",
   "types": "./build/es2020/index.d.ts",
@@ -127,5 +127,6 @@
       "packageLocks": [],
       "files": []
     }
-  }
+  },
+  "stableVersion": "0.0.9"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madatdata/react",
-  "version": "0.0.9",
+  "version": "0.0.10-0",
   "packageManager": "yarn@3.2.0",
   "main": "index.ts",
   "types": "./build/es2020/index.d.ts",
@@ -50,5 +50,6 @@
   "files": [
     "build/*/**",
     "package.json"
-  ]
+  ],
+  "stableVersion": "0.0.9"
 }


### PR DESCRIPTION
Release the contents of #15 under tag `canary`

You should be able to install with `yarn install -E '@madatdata/core@canary'` (the`-E` is optional, I think it will just make it resolve to `0.0.10-0`, which is the current release of the `canary` tag).

I haven't tried this myself yet, and this code is mostly untested outside of unit tests. YMMV.