### PR TITLE
Simplify function signatures of `makeSeafowlHTTPContext` and `makeSplitgraphHTTPContext`

### DIFF
--- a/packages/core/seafowl.test.ts
+++ b/packages/core/seafowl.test.ts
@@ -30,6 +30,43 @@ const expectToken = SEAFOWL_SECRET ?? "anonymous-token";
 // keeping track of what the actual response looks like so we can mock it accurately.
 // const shouldSkipSeafowl = true;
 
+describe("interface", () => {
+  it("can be created with instance URL string", () => {
+    const simpleContext = makeSeafowlHTTPContext("https://demo.seafowl.cloud");
+
+    expect(
+      // @ts-expect-error Abuse private property "host" to skip serializing a giant snapshot
+      simpleContext.client.host.baseUrls.sql
+    ).toEqual("https://demo.seafowl.cloud");
+
+    expect(
+      // @ts-expect-error Abuse private property "host" to skip serializing a giant snapshot
+      simpleContext.client.host.dataHost
+    ).toEqual("demo.seafowl.cloud");
+  });
+
+  it("can be created with instance URL string, and simplified opts (dbname)", () => {
+    const simpleContext = makeSeafowlHTTPContext("https://demo.seafowl.cloud", {
+      dbname: "alternative",
+    });
+
+    expect(
+      // @ts-expect-error Abuse private property "database" to skip serializing a giant snapshot
+      simpleContext.client.database.dbname
+    ).toEqual("alternative");
+
+    expect(
+      // @ts-expect-error Abuse private property "host" to skip serializing a giant snapshot
+      simpleContext.client.host.baseUrls.sql
+    ).toEqual("https://demo.seafowl.cloud");
+
+    expect(
+      // @ts-expect-error Abuse private property "host" to skip serializing a giant snapshot
+      simpleContext.client.host.dataHost
+    ).toEqual("demo.seafowl.cloud");
+  });
+});
+
 describe("abort signal", () => {
   it("can take it as an option to execute", async () => {
     const ctx = createDataContext({

--- a/packages/core/splitgraph.test.ts
+++ b/packages/core/splitgraph.test.ts
@@ -13,6 +13,7 @@ import { setupMemo } from "@madatdata/test-helpers/setup-memo";
 import type { IsomorphicRequest } from "@mswjs/interceptors";
 
 import { createDataContext } from "./test-helpers/splitgraph-test-helpers";
+import { makeSplitgraphHTTPContext } from "./splitgraph";
 
 const minSuccessfulJSON = {
   success: true,
@@ -38,6 +39,43 @@ const minSuccessfulJSON = {
   executionTime: "128ms",
   executionTimeHighRes: "0s 128.383115ms",
 };
+
+describe("simplified interface", () => {
+  it("can be called with no options", () => {
+    const simplifiedContext = makeSplitgraphHTTPContext();
+
+    expect(
+      // @ts-expect-error Abuse private property "credential" to avoid giant snapshot serialization
+      simplifiedContext.client.credential
+    ).toMatchInlineSnapshot(`
+      {
+        "anonymous": true,
+        "token": "anonymous-token",
+      }
+    `);
+
+    expect(
+      // @ts-expect-error Abuse private property "credential" to avoid giant snapshot serialization
+      simplifiedContext.client.host
+    ).toMatchInlineSnapshot(`
+      {
+        "apexDomain": "splitgraph.com",
+        "apiHost": "api.splitgraph.com",
+        "baseUrls": {
+          "auth": "https://api.splitgraph.com/auth",
+          "gql": "https://api.splitgraph.com/gql/cloud/unified/graphql",
+          "sql": "https://data.splitgraph.com/sql/query",
+        },
+        "dataHost": "data.splitgraph.com",
+        "postgres": {
+          "host": "data.splitgraph.com",
+          "port": 5432,
+          "ssl": true,
+        },
+      }
+    `);
+  });
+});
 
 describe("makeSplitgraphHTTPContext with http strategies", () => {
   setupMswServerTestHooks();

--- a/packages/core/splitgraph.ts
+++ b/packages/core/splitgraph.ts
@@ -10,20 +10,35 @@ export { defaultDatabase as defaultSplitgraphDatabase };
 export { defaultHost as defaultSplitgraphHost };
 
 export type SplitgraphDataContext = ReturnType<
-  typeof makeSplitgraphHTTPContext
+  typeof makeSplitgraphHTTPContextWithOpts
 >;
 
-export const makeSplitgraphHTTPContext = (
-  opts?: {
-    client?: Parameters<typeof makeClient>[0];
-    db?: Parameters<typeof makeDb>[0];
-  } & Partial<
-    Omit<
-      Parameters<typeof makeClient>[0] & Parameters<typeof makeDb>[0],
-      "client" | "db"
-    >
+export type SplitgraphDataContextOpts = {
+  client?: Parameters<typeof makeClient>[0];
+  db?: Parameters<typeof makeDb>[0];
+} & Partial<
+  Omit<
+    Parameters<typeof makeClient>[0] & Parameters<typeof makeDb>[0],
+    "client" | "db"
   >
-) => {
+>;
+
+/**
+ * Call with no options to create a data context that is anonymous and targeting
+ * the public Splitgraph DDN at data.splitgraph.com.
+ *
+ *
+ * @param opts Optional options argument. If none are defined, default to anonymous public DDN
+ */
+export const makeSplitgraphHTTPContext = (opts?: SplitgraphDataContextOpts) => {
+  if (typeof opts === "undefined") {
+    return makeSplitgraphHTTPContextWithOpts({ credential: null });
+  }
+
+  return makeSplitgraphHTTPContextWithOpts(opts);
+};
+
+const makeSplitgraphHTTPContextWithOpts = (opts: SplitgraphDataContextOpts) => {
   const dbOpts = {
     authenticatedCredential:
       opts?.db?.authenticatedCredential ??

--- a/packages/core/test-helpers/seafowl-test-helpers.ts
+++ b/packages/core/test-helpers/seafowl-test-helpers.ts
@@ -1,10 +1,13 @@
 import { makeSeafowlHTTPContext } from "../seafowl";
+import type { SeafowlDataContextOpts } from "../seafowl";
 
 // @ts-expect-error https://stackoverflow.com/a/70711231
 export const SEAFOWL_SECRET = import.meta.env.VITE_TEST_SEAFOWL_SECRET;
 
 export const createDataContext = (
-  opts?: Parameters<typeof makeSeafowlHTTPContext>[0] & { secret?: string }
+  opts?: SeafowlDataContextOpts & {
+    secret?: string;
+  }
 ) => {
   return makeSeafowlHTTPContext({
     database: {

--- a/packages/db-seafowl/db-seafowl.ts
+++ b/packages/db-seafowl/db-seafowl.ts
@@ -81,7 +81,18 @@ const guessMethodForQuery = (query: string) => {
   if (writeStatements.some((write) => normalizedQuery.startsWith(write))) {
     return "POST";
   }
-  if (!query.includes("SELECT")) {
+
+  // NOTE: This might include non-write CTE statements, but that failure case is just not caching them
+  // which is better than sending a write CTE statement as a GET (which would fail)
+  if (
+    normalizedQuery.startsWith("WITH") &&
+    normalizedQuery.includes("CREATE")
+  ) {
+    console.warn("Query starts with WITH and includes CREATE, assume write:");
+    return "POST";
+  }
+
+  if (!normalizedQuery.includes("SELECT")) {
     console.warn("No SELECT in query, but assuming GET:", query);
   }
 


### PR DESCRIPTION
Allow calling both `makeSeafowlHTTPContext` and `makeSplitgraphHTTPContext` with minimal (or no) arguments.

**Seafowl**

For Seafowl, with default `dbname` (note the endpoint does _not_ include the `/q`, and _does_ include the `https://`):

```ts
import { makeSeafowlHTTPContext } from "@madatdata/core";
const { client } = makeSeafowlHTTPContext("https://demo.seafowl.cloud");
```

Or, for a different `dbname`:

```ts
import { makeSeafowlHTTPContext } from "@madatdata/core";
const { client } = makeSeafowlHTTPContext("https://demo.seafowl.cloud", { dbname: "alternative" });
```

**Splitgraph**

For Splitgraph, anonymous DDN:

```ts
import { makeSplitgraphHTTPContext } from "@madatdata/core";
const { client } = makeSplitgraphHTTPContext();
```

For Splitgraph, with an API key and secret:

```ts
import { makeSplitgraphHTTPContext } from "@madatdata/core";
const { client } = makeSplitgraphHTTPContext({credential: { apiKey: "xxx", apiSecret: "yyy" }});
```